### PR TITLE
Optimize RLP encoding paths

### DIFF
--- a/brane-primitives/README.md
+++ b/brane-primitives/README.md
@@ -3,5 +3,26 @@
 Core primitive utilities with zero external dependencies.
 
 ## Features
-- Hex encoding/decoding utilities
-- Foundation for future primitive helpers
+- Hex encoding/decoding ✓
+- RLP encoding/decoding ✓
+
+## RLP Usage
+
+```java
+import io.brane.primitives.rlp.*;
+import java.nio.charset.StandardCharsets;
+
+// Encode a string
+RlpString str = RlpString.of("hello".getBytes(StandardCharsets.US_ASCII));
+byte[] encoded = str.encode();
+
+// Encode a list
+RlpList list = RlpList.of(
+        RlpString.of("cat".getBytes(StandardCharsets.US_ASCII)),
+        RlpString.of("dog".getBytes(StandardCharsets.US_ASCII))
+);
+byte[] encodedList = list.encode();
+
+// Decode
+RlpItem decoded = Rlp.decode(encodedList);
+```

--- a/brane-primitives/src/main/java/io/brane/primitives/rlp/Rlp.java
+++ b/brane-primitives/src/main/java/io/brane/primitives/rlp/Rlp.java
@@ -1,0 +1,282 @@
+package io.brane.primitives.rlp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Utility methods for encoding and decoding Recursive Length Prefix (RLP) data.
+ */
+public final class Rlp {
+    private Rlp() {
+        // Utility class
+    }
+
+    /**
+     * Encodes the provided item to RLP bytes.
+     *
+     * @param item the item to encode
+     * @return encoded bytes
+     */
+    public static byte[] encode(final RlpItem item) {
+        Objects.requireNonNull(item, "item cannot be null");
+        return item.encode();
+    }
+
+    /**
+     * Encodes the provided byte string into RLP format.
+     *
+     * @param bytes the raw bytes to encode
+     * @return encoded bytes
+     */
+    public static byte[] encodeString(final byte[] bytes) {
+        Objects.requireNonNull(bytes, "bytes cannot be null");
+
+        if (bytes.length == 1 && (bytes[0] & 0xFF) <= 0x7F) {
+            // Single byte [0x00, 0x7f]
+            return Arrays.copyOf(bytes, bytes.length);
+        }
+
+        if (bytes.length <= 55) {
+            final byte[] result = new byte[1 + bytes.length];
+            result[0] = (byte) (0x80 + bytes.length);
+            System.arraycopy(bytes, 0, result, 1, bytes.length);
+            return result;
+        }
+
+        final byte[] lengthBytes = toMinimalBytes(bytes.length);
+        final byte[] result = new byte[1 + lengthBytes.length + bytes.length];
+        result[0] = (byte) (0xB7 + lengthBytes.length);
+        System.arraycopy(lengthBytes, 0, result, 1, lengthBytes.length);
+        System.arraycopy(bytes, 0, result, 1 + lengthBytes.length, bytes.length);
+        return result;
+    }
+
+    /**
+     * Encodes the provided list of RLP items.
+     *
+     * @param items the items to encode
+     * @return encoded bytes
+     */
+    public static byte[] encodeList(final List<RlpItem> items) {
+        Objects.requireNonNull(items, "items cannot be null");
+        for (final RlpItem item : items) {
+            Objects.requireNonNull(item, "items cannot contain null values");
+        }
+        final byte[][] encodedItems = new byte[items.size()][];
+        int totalLength = 0;
+        for (int i = 0; i < items.size(); i++) {
+            final byte[] encoded = items.get(i).encode();
+            encodedItems[i] = encoded;
+            totalLength += encoded.length;
+        }
+
+        if (totalLength <= 55) {
+            final byte[] result = new byte[1 + totalLength];
+            result[0] = (byte) (0xC0 + totalLength);
+            int offset = 1;
+            for (final byte[] encoded : encodedItems) {
+                System.arraycopy(encoded, 0, result, offset, encoded.length);
+                offset += encoded.length;
+            }
+            return result;
+        }
+
+        final byte[] lengthBytes = toMinimalBytes(totalLength);
+        final byte[] result = new byte[1 + lengthBytes.length + totalLength];
+        result[0] = (byte) (0xF7 + lengthBytes.length);
+        System.arraycopy(lengthBytes, 0, result, 1, lengthBytes.length);
+        int offset = 1 + lengthBytes.length;
+        for (final byte[] encoded : encodedItems) {
+            System.arraycopy(encoded, 0, result, offset, encoded.length);
+            offset += encoded.length;
+        }
+        return result;
+    }
+
+    /**
+     * Decodes the provided RLP byte array into an {@link RlpItem}.
+     *
+     * @param encoded the encoded bytes
+     * @return decoded item
+     */
+    public static RlpItem decode(final byte[] encoded) {
+        Objects.requireNonNull(encoded, "encoded cannot be null");
+        final DecodeResult result = decode(encoded, 0);
+        if (result.consumed != encoded.length) {
+            throw new IllegalArgumentException("RLP data has trailing bytes");
+        }
+        return result.item;
+    }
+
+    /**
+     * Decodes the provided RLP byte array, expecting a list at the root.
+     *
+     * @param encoded the encoded bytes representing a list
+     * @return decoded list items
+     */
+    public static List<RlpItem> decodeList(final byte[] encoded) {
+        final RlpItem item = decode(encoded);
+        if (item instanceof RlpList list) {
+            return list.items();
+        }
+        throw new IllegalArgumentException("RLP data is not a list");
+    }
+
+    private static DecodeResult decode(final byte[] data, final int offset) {
+        if (offset >= data.length) {
+            throw new IllegalArgumentException("Invalid RLP data: offset beyond end");
+        }
+
+        final int prefix = data[offset] & 0xFF;
+
+        if (prefix <= 0x7F) {
+            return new DecodeResult(new RlpString(new byte[] {(byte) prefix}), 1);
+        }
+        if (prefix <= 0xB7) {
+            final int length = prefix - 0x80;
+            return decodeString(data, offset, length, 1);
+        }
+        if (prefix <= 0xBF) {
+            final int lengthOfLength = prefix - 0xB7;
+            return decodeLongString(data, offset, lengthOfLength);
+        }
+        if (prefix <= 0xF7) {
+            final int length = prefix - 0xC0;
+            return decodeList(data, offset, length, 1);
+        }
+
+        final int lengthOfLength = prefix - 0xF7;
+        return decodeLongList(data, offset, lengthOfLength);
+    }
+
+    private static DecodeResult decodeString(
+            final byte[] data, final int offset, final int length, final int headerSize) {
+        final int start = offset + headerSize;
+        final int end = start + length;
+        if (end > data.length) {
+            throw new IllegalArgumentException("Invalid RLP string length");
+        }
+        final byte[] value = Arrays.copyOfRange(data, start, end);
+        return new DecodeResult(new RlpString(value), headerSize + length);
+    }
+
+    private static DecodeResult decodeLongString(
+            final byte[] data, final int offset, final int lengthOfLength) {
+        final int lengthStart = offset + 1;
+        final int lengthEnd = lengthStart + lengthOfLength;
+        if (lengthEnd > data.length) {
+            throw new IllegalArgumentException("Invalid RLP long string length");
+        }
+
+        final int length = readLength(data, lengthStart, lengthOfLength);
+        if (length < 56) {
+            throw new IllegalArgumentException("Non-minimal length encoding for string");
+        }
+
+        final int valueStart = lengthEnd;
+        final int valueEnd = valueStart + length;
+        if (valueEnd > data.length) {
+            throw new IllegalArgumentException("Invalid RLP string length");
+        }
+
+        final byte[] value = Arrays.copyOfRange(data, valueStart, valueEnd);
+        return new DecodeResult(new RlpString(value), 1 + lengthOfLength + length);
+    }
+
+    private static DecodeResult decodeList(
+            final byte[] data, final int offset, final int length, final int headerSize) {
+        final int start = offset + headerSize;
+        final int end = start + length;
+        if (end > data.length) {
+            throw new IllegalArgumentException("Invalid RLP list length");
+        }
+
+        final List<RlpItem> items = new ArrayList<>();
+        int currentOffset = start;
+        while (currentOffset < end) {
+            final DecodeResult child = decode(data, currentOffset);
+            items.add(child.item);
+            currentOffset += child.consumed;
+        }
+
+        if (currentOffset != end) {
+            throw new IllegalArgumentException("RLP list length mismatch");
+        }
+
+        return new DecodeResult(new RlpList(items), headerSize + length);
+    }
+
+    private static DecodeResult decodeLongList(
+            final byte[] data, final int offset, final int lengthOfLength) {
+        final int lengthStart = offset + 1;
+        final int lengthEnd = lengthStart + lengthOfLength;
+        if (lengthEnd > data.length) {
+            throw new IllegalArgumentException("Invalid RLP long list length");
+        }
+
+        final int length = readLength(data, lengthStart, lengthOfLength);
+        if (length < 56) {
+            throw new IllegalArgumentException("Non-minimal length encoding for list");
+        }
+
+        return decodeList(data, offset, length, 1 + lengthOfLength);
+    }
+
+    private static int readLength(final byte[] data, final int start, final int lengthOfLength) {
+        if (lengthOfLength < 1 || lengthOfLength > 8) {
+            throw new IllegalArgumentException("Invalid length of length");
+        }
+        if (data[start] == 0) {
+            throw new IllegalArgumentException("Length has leading zeros");
+        }
+
+        int length = 0;
+        for (int i = 0; i < lengthOfLength; i++) {
+            length = (length << 8) + (data[start + i] & 0xFF);
+        }
+        return length;
+    }
+
+    private static byte[] toMinimalBytes(final int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("Length cannot be negative");
+        }
+        if (value == 0) {
+            return new byte[] {0};
+        }
+
+        final int size = (32 - Integer.numberOfLeadingZeros(value) + 7) / 8;
+        final byte[] result = new byte[size];
+        for (int i = size - 1; i >= 0; i--) {
+            result[i] = (byte) (value >>> (8 * (size - 1 - i)));
+        }
+        return result;
+    }
+
+    private static byte[] concat(final byte[]... arrays) {
+        int total = 0;
+        for (final byte[] array : arrays) {
+            total += array.length;
+        }
+
+        final byte[] result = new byte[total];
+        int offset = 0;
+        for (final byte[] array : arrays) {
+            System.arraycopy(array, 0, result, offset, array.length);
+            offset += array.length;
+        }
+        return result;
+    }
+
+    private static byte[] concat(final byte first, final byte[]... arrays) {
+        final byte[] firstArray = new byte[] {first};
+        final byte[][] all = new byte[arrays.length + 1][];
+        all[0] = firstArray;
+        System.arraycopy(arrays, 0, all, 1, arrays.length);
+        return concat(all);
+    }
+
+    private record DecodeResult(RlpItem item, int consumed) {}
+}

--- a/brane-primitives/src/main/java/io/brane/primitives/rlp/RlpItem.java
+++ b/brane-primitives/src/main/java/io/brane/primitives/rlp/RlpItem.java
@@ -1,0 +1,13 @@
+package io.brane.primitives.rlp;
+
+/**
+ * Base sealed interface for all RLP items.
+ */
+public sealed interface RlpItem permits RlpString, RlpList {
+    /**
+     * Encodes this item into RLP byte representation.
+     *
+     * @return encoded bytes
+     */
+    byte[] encode();
+}

--- a/brane-primitives/src/main/java/io/brane/primitives/rlp/RlpList.java
+++ b/brane-primitives/src/main/java/io/brane/primitives/rlp/RlpList.java
@@ -1,0 +1,50 @@
+package io.brane.primitives.rlp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * RLP representation of a list of items.
+ */
+public record RlpList(List<RlpItem> items) implements RlpItem {
+    /**
+     * Constructs an {@link RlpList} with a defensive copy of items.
+     *
+     * @param items the items to include in the list
+     */
+    public RlpList {
+        Objects.requireNonNull(items, "items cannot be null");
+        items = Collections.unmodifiableList(new ArrayList<>(items));
+        if (items.contains(null)) {
+            throw new IllegalArgumentException("items cannot contain null values");
+        }
+    }
+
+    /**
+     * Creates an {@link RlpList} from the provided items.
+     *
+     * @param items the items to include
+     * @return {@link RlpList} containing the provided items
+     */
+    public static RlpList of(final RlpItem... items) {
+        return new RlpList(Arrays.asList(items));
+    }
+
+    /**
+     * Creates an {@link RlpList} from the provided list of items.
+     *
+     * @param items the items to include
+     * @return {@link RlpList} containing the provided items
+     */
+    public static RlpList of(final List<RlpItem> items) {
+        return new RlpList(items);
+    }
+
+    @Override
+    public byte[] encode() {
+        return Rlp.encodeList(items);
+    }
+}

--- a/brane-primitives/src/main/java/io/brane/primitives/rlp/RlpString.java
+++ b/brane-primitives/src/main/java/io/brane/primitives/rlp/RlpString.java
@@ -1,0 +1,103 @@
+package io.brane.primitives.rlp;
+
+import io.brane.primitives.Hex;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * RLP representation of a byte string.
+ */
+public record RlpString(byte[] bytes) implements RlpItem {
+    /**
+     * Constructs an {@link RlpString} copying the provided bytes.
+     *
+     * @param bytes the value to wrap
+     */
+    public RlpString {
+        Objects.requireNonNull(bytes, "bytes cannot be null");
+        bytes = Arrays.copyOf(bytes, bytes.length);
+    }
+
+    /**
+     * Creates an {@link RlpString} from the provided bytes.
+     *
+     * @param bytes the bytes to wrap
+     * @return {@link RlpString} wrapping the provided bytes
+     */
+    public static RlpString of(final byte[] bytes) {
+        return new RlpString(bytes);
+    }
+
+    /**
+     * Creates an {@link RlpString} from a hex string with or without {@code 0x} prefix.
+     *
+     * @param hex the hex string to decode
+     * @return {@link RlpString} wrapping the decoded bytes
+     */
+    public static RlpString of(final String hex) {
+        return new RlpString(Hex.decode(hex));
+    }
+
+    /**
+     * Creates an {@link RlpString} from a non-negative long value using minimal big-endian representation.
+     *
+     * @param value the value to encode
+     * @return {@link RlpString} wrapping the encoded value
+     * @throws IllegalArgumentException if {@code value} is negative
+     */
+    public static RlpString of(final long value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("RLP numeric values must be non-negative");
+        }
+        return new RlpString(toMinimalBytes(BigInteger.valueOf(value)));
+    }
+
+    /**
+     * Creates an {@link RlpString} from a non-negative {@link BigInteger} using minimal big-endian representation.
+     *
+     * @param value the value to encode
+     * @return {@link RlpString} wrapping the encoded value
+     * @throws IllegalArgumentException if {@code value} is null or negative
+     */
+    public static RlpString of(final BigInteger value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        if (value.signum() < 0) {
+            throw new IllegalArgumentException("RLP numeric values must be non-negative");
+        }
+        return new RlpString(toMinimalBytes(value));
+    }
+
+    @Override
+    public byte[] encode() {
+        return Rlp.encodeString(bytes);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RlpString other)) {
+            return false;
+        }
+        return Arrays.equals(bytes, other.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bytes);
+    }
+
+    private static byte[] toMinimalBytes(final BigInteger value) {
+        if (value.equals(BigInteger.ZERO)) {
+            return new byte[] {0};
+        }
+
+        final byte[] raw = value.toByteArray();
+        if (raw[0] == 0) {
+            return Arrays.copyOfRange(raw, 1, raw.length);
+        }
+        return raw;
+    }
+}

--- a/brane-primitives/src/test/java/io/brane/primitives/rlp/RlpTest.java
+++ b/brane-primitives/src/test/java/io/brane/primitives/rlp/RlpTest.java
@@ -1,0 +1,94 @@
+package io.brane.primitives.rlp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.brane.primitives.Hex;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RlpTest {
+    @Test
+    @DisplayName("String encoding vectors from Ethereum RLP spec")
+    void testStringEncodingVectors() {
+        assertEquals("80", Hex.encodeNoPrefix(RlpString.of(new byte[] {}).encode()));
+        assertEquals(
+                "83646f67",
+                Hex.encodeNoPrefix(RlpString.of("dog".getBytes(StandardCharsets.US_ASCII)).encode()));
+        assertEquals("00", Hex.encodeNoPrefix(RlpString.of(new byte[] {0x00}).encode()));
+        assertEquals("0f", Hex.encodeNoPrefix(RlpString.of(new byte[] {0x0f}).encode()));
+        assertEquals("820400", Hex.encodeNoPrefix(RlpString.of(1024L).encode()));
+    }
+
+    @Test
+    @DisplayName("List encoding vectors from Ethereum RLP spec")
+    void testListEncodingVectors() {
+        assertEquals("c0", Hex.encodeNoPrefix(RlpList.of().encode()));
+
+        final RlpList animals =
+                RlpList.of(
+                        RlpString.of("cat".getBytes(StandardCharsets.US_ASCII)),
+                        RlpString.of("dog".getBytes(StandardCharsets.US_ASCII)));
+        assertEquals("c88363617483646f67", Hex.encodeNoPrefix(animals.encode()));
+
+        final RlpList nestedEmpty = RlpList.of(RlpList.of());
+        assertEquals("c1c0", Hex.encodeNoPrefix(nestedEmpty.encode()));
+    }
+
+    @Test
+    void testRoundTripEncodeDecode() {
+        final List<RlpItem> samples = List.of(
+                RlpString.of(new byte[] {}),
+                RlpString.of(BigInteger.ZERO),
+                RlpString.of(15L),
+                RlpList.of(
+                        RlpString.of("hello".getBytes(StandardCharsets.US_ASCII)),
+                        RlpList.of(RlpString.of(1024L))),
+                RlpList.of(
+                        RlpString.of(new byte[60]),
+                        RlpList.of(RlpString.of("braneworld".getBytes(StandardCharsets.US_ASCII)))));
+
+        for (final RlpItem item : samples) {
+            final byte[] encoded = Rlp.encode(item);
+            final RlpItem decoded = Rlp.decode(encoded);
+            assertEquals(item, decoded);
+        }
+    }
+
+    @Test
+    void testLongStringAndListEncoding() {
+        final byte[] longString = new byte[60];
+        Arrays.fill(longString, (byte) 0x01);
+
+        final byte[] encodedString = RlpString.of(longString).encode();
+        assertEquals((byte) 0xB8, encodedString[0]);
+        assertEquals((byte) 0x3C, encodedString[1]);
+        assertEquals(62, encodedString.length);
+        assertArrayEquals(longString, ((RlpString) Rlp.decode(encodedString)).bytes());
+
+        final List<RlpItem> manyItems = new ArrayList<>();
+        for (int i = 0; i < 60; i++) {
+            manyItems.add(RlpString.of((long) i));
+        }
+        final byte[] encodedList = RlpList.of(manyItems).encode();
+        assertEquals((byte) 0xF8, encodedList[0]);
+        assertEquals((byte) 0x3C, encodedList[1]);
+        final List<RlpItem> decoded = Rlp.decodeList(encodedList);
+        assertEquals(60, decoded.size());
+        for (int i = 0; i < decoded.size(); i++) {
+            assertEquals(RlpString.of((long) i), decoded.get(i));
+        }
+    }
+
+    @Test
+    void testDecodeListGuardrails() {
+        assertThrows(IllegalArgumentException.class, () -> Rlp.decodeList(RlpString.of(1L).encode()));
+
+        final byte[] invalidLength = new byte[] {(byte) 0xB8, 0x01, 0x00};
+        assertThrows(IllegalArgumentException.class, () -> Rlp.decode(invalidLength));
+    }
+}


### PR DESCRIPTION
## Summary
- streamline RLP string encoding to avoid concat overhead for medium and long payloads
- encode lists in a single pass with pre-sized buffers to better handle nested structures
- reduce length prefix calculation overhead for large payload sizes

## Testing
- ./gradlew :brane-primitives:test --no-daemon *(fails: dependency downloads blocked by 403 responses from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692272522c208328849ff73cc94018b0)