### PR TITLE
docs: add simulate section to navigation

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -22,6 +22,7 @@
             "group": "Public Client",
             "pages": [
                 "public-client/api",
+                "public-client/simulate",
                 "public-client/subscriptions"
             ]
         },


### PR DESCRIPTION
Make the simulate page visible in the Public Client sidebar instead of only being accessible via a hyperlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)