### PR TITLE
feat(ci): add GitHub Actions workflow for build and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'website/**'
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE*'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'website/**'
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Check formatting
+        run: ./gradlew spotlessCheck
+
+      - name: Build
+        run: ./gradlew assemble
+
+      - name: Unit tests
+        run: ./gradlew test -Pbrane.unit.tests
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results
+          path: '**/build/reports/tests/'
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add CI workflow that runs on PRs and pushes to main
- Spotless formatting check
- Build all modules  
- Unit tests (excludes integration tests requiring Anvil)
- Test results uploaded on failure

## Test plan
- [x] Push triggers workflow
- [ ] Verify spotless check passes
- [ ] Verify build succeeds
- [ ] Verify unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)