### PR TITLE
fix: align nav bar padding on desktop and mobile

### DIFF
--- a/website/docs/public/styles.css
+++ b/website/docs/public/styles.css
@@ -24,14 +24,19 @@
   padding: 0 !important;
 }
 
-/* Remove the withLogo modifier spacing */
+/* Remove the withLogo modifier spacing but keep aligned with right side */
 .vocs_DesktopTopNav.vocs_DesktopTopNav_withLogo {
-  padding-left: 0;
+  padding-left: var(--vocs-content_horizontalPadding);
 }
 
 /* Ensure nav items stay on the right */
 .vocs_DesktopTopNav_section:has(.vocs_DesktopTopNav_group) {
   margin-left: auto;
+}
+
+/* Fix mobile nav search alignment (override inline marginRight: -8px) */
+.vocs_MobileTopNav .vocs_MobileTopNav_group:has(.vocs_MobileSearch_searchButton) {
+  margin-right: 0 !important;
 }
 
 [data-layout="landing"] .vocs_Button_button {


### PR DESCRIPTION
## Summary
- Fixes asymmetric padding in the navigation bar where the search input/icon had less spacing from the edge compared to the right-side nav items
- **Desktop**: Changed `padding-left: 0` to use the CSS variable `--vocs-content_horizontalPadding`, which automatically adjusts at different breakpoints to match the right side
- **Mobile**: Overrides an inline `marginRight: -8px` on the search button wrapper that was pulling it closer to the right edge

## Test plan
- [x] Desktop nav: verify search box on left has same padding as Docs/GitHub links on right
- [x] Mobile nav: verify logo/menu on left has same padding as search icon on right
- [x] Check at various breakpoints (>1080px, <1080px, <720px) to ensure padding stays consistent