### PR TITLE
chore: update license copyright to 2025 Brane Contributors

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2025 Brane Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Brane Contributors
+Copyright (c) 2025 Brane Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Fill in LICENSE-APACHE APPENDIX placeholder with actual copyright
- Update LICENSE-MIT year from 2024 to 2025

Prepares the repo for public OSS launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)