### PR TITLE
chore: add automated PR review workflow

### DIFF
--- a/.github/project-pr-review-rules.md
+++ b/.github/project-pr-review-rules.md
@@ -1,0 +1,25 @@
+# brane Project PR Review Rules
+
+## Auto-Approval Policy
+AUTO_APPROVE_BLOCK_SEVERITY: HIGH
+
+## CRITICAL
+- Flag secrets, private keys, or mnemonics committed to any file (including test fixtures that aren't the documented default test key).
+- Flag PrivateKey instances not being destroyed after use, or MnemonicWallet instances held longer than necessary.
+- Flag Keccak256 ThreadLocal not being cleaned up in pooled/web thread contexts.
+
+## HIGH
+- Flag violations of sealed type hierarchies (unsealed interfaces/classes where sealed is expected).
+- Flag allocation-heavy patterns in hot paths where zero-allocation `*To()` variants exist (e.g., `Hex.decode()` instead of `Hex.decodeTo()`, `Hex.encode()` instead of `Hex.encodeTo()`).
+- Flag missing or incorrect Javadoc `<b>Allocation:</b>` tags on new public methods.
+- Flag direct byte array manipulation without using singleton constants (`Address.ZERO`, `Wei.ZERO`) where applicable.
+- Flag missing tests for behavior changes (unit tests at minimum; integration/smoke tests for chain interaction).
+
+## MEDIUM
+- Flag inconsistent use of Java 21 patterns (records, pattern matching, virtual threads) where they would simplify code.
+- Flag readability issues in large files (500+ lines) without clear section organization.
+
+## Never Flag
+- Formatting-only changes.
+- Existing baseline issues unchanged by the diff.
+- The default Anvil test key `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80` in test code.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,21 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    uses: noise-xyz/noise-terraform/.github/workflows/pr-review-reusable.yml@3d91312dae364bcce530709db73a8605c1b69ed5
+    with:
+      project-review-rules-path: .github/project-pr-review-rules.md
+      auto-approve: true
+      dedupe-with-other-bots: true
+      auto-update-pr-description: true
+    secrets: inherit


### PR DESCRIPTION
Adds the reusable Claude PR review workflow and project-specific review rules.

**Files added:**
- `.github/workflows/pr-review.yml` — calls the reusable workflow from `noise-terraform`
- `.github/project-pr-review-rules.md` — project-specific review rules

Pinned to `noise-terraform@3d91312`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/noise-xyz/brane/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
