### PR TITLE
perf: reduce heap allocations on hot paths

### DIFF
--- a/brane-benchmark/src/jmh/java/sh/brane/benchmark/Eip712AllocationBenchmark.java
+++ b/brane-benchmark/src/jmh/java/sh/brane/benchmark/Eip712AllocationBenchmark.java
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.benchmark;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+
+import sh.brane.core.crypto.eip712.Eip712Domain;
+import sh.brane.core.crypto.eip712.TypeDefinition;
+import sh.brane.core.crypto.eip712.TypedData;
+import sh.brane.core.crypto.eip712.TypedDataField;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.Hash;
+
+/**
+ * JMH benchmark for measuring allocation patterns in EIP-712 typed data hashing.
+ *
+ * <p>Measures the allocation cost of computing EIP-712 struct hashes,
+ * including domain separator computation, type encoding, and data encoding.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(1)
+public class Eip712AllocationBenchmark {
+
+    // ═══════════════════════════════════════════════════════════════
+    // Simple struct: Permit (5 fields, no nesting)
+    // ═══════════════════════════════════════════════════════════════
+
+    record Permit(Address owner, Address spender, BigInteger value, BigInteger nonce, BigInteger deadline) {}
+
+    private static final Map<String, List<TypedDataField>> PERMIT_TYPES = Map.of(
+        "Permit", List.of(
+            TypedDataField.of("owner", "address"),
+            TypedDataField.of("spender", "address"),
+            TypedDataField.of("value", "uint256"),
+            TypedDataField.of("nonce", "uint256"),
+            TypedDataField.of("deadline", "uint256")
+        )
+    );
+
+    private static final TypeDefinition<Permit> PERMIT_DEFINITION =
+        TypeDefinition.forRecord(Permit.class, "Permit", PERMIT_TYPES);
+
+    // ═══════════════════════════════════════════════════════════════
+    // Nested struct: Mail with Person sub-struct
+    // ═══════════════════════════════════════════════════════════════
+
+    record Person(String name, Address wallet) {}
+    record Mail(Person from, Person to, String contents) {}
+
+    private static final Map<String, List<TypedDataField>> MAIL_TYPES = Map.of(
+        "Mail", List.of(
+            TypedDataField.of("from", "Person"),
+            TypedDataField.of("to", "Person"),
+            TypedDataField.of("contents", "string")
+        ),
+        "Person", List.of(
+            TypedDataField.of("name", "string"),
+            TypedDataField.of("wallet", "address")
+        )
+    );
+
+    @SuppressWarnings("unchecked")
+    private static final TypeDefinition<Mail> MAIL_DEFINITION =
+        new TypeDefinition<>(
+            "Mail",
+            MAIL_TYPES,
+            mail -> Map.of(
+                "from", (Object) Map.of(
+                    "name", mail.from().name(),
+                    "wallet", mail.from().wallet()
+                ),
+                "to", (Object) Map.of(
+                    "name", mail.to().name(),
+                    "wallet", mail.to().wallet()
+                ),
+                "contents", mail.contents()
+            )
+        );
+
+    // ═══════════════════════════════════════════════════════════════
+    // Test data
+    // ═══════════════════════════════════════════════════════════════
+
+    private TypedData<Permit> simpleTypedData;
+    private TypedData<Mail> nestedTypedData;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        var domain = Eip712Domain.builder()
+            .name("TestDapp")
+            .version("1")
+            .chainId(1)
+            .verifyingContract(new Address("0x1234567890123456789012345678901234567890"))
+            .build();
+
+        var permit = new Permit(
+            new Address("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            new Address("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            BigInteger.valueOf(1000000000000000000L),
+            BigInteger.ZERO,
+            BigInteger.valueOf(1234567890)
+        );
+        simpleTypedData = TypedData.create(domain, PERMIT_DEFINITION, permit);
+
+        var mail = new Mail(
+            new Person("Alice", new Address("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+            new Person("Bob", new Address("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
+            "Hello, Bob!"
+        );
+        nestedTypedData = TypedData.create(domain, MAIL_DEFINITION, mail);
+    }
+
+    /**
+     * Benchmarks hashing a simple struct (Permit — 5 flat fields, no nesting).
+     * Measures allocation from TypedDataEncoder.encodeData + typeHash + hashStruct.
+     *
+     * @return the EIP-712 hash (for blackhole consumption)
+     */
+    @Benchmark
+    public Hash hashSimpleStruct() {
+        return simpleTypedData.hash();
+    }
+
+    /**
+     * Benchmarks hashing a nested struct (Mail with Person sub-structs).
+     * Measures additional allocation from recursive struct encoding.
+     *
+     * @return the EIP-712 hash (for blackhole consumption)
+     */
+    @Benchmark
+    public Hash hashNestedStruct() {
+        return nestedTypedData.hash();
+    }
+}

--- a/brane-benchmark/src/jmh/java/sh/brane/benchmark/TxEncodeAllocationBenchmark.java
+++ b/brane-benchmark/src/jmh/java/sh/brane/benchmark/TxEncodeAllocationBenchmark.java
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.benchmark;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+
+import sh.brane.core.crypto.Signature;
+import sh.brane.core.tx.Eip1559Transaction;
+import sh.brane.core.tx.LegacyTransaction;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.HexData;
+import sh.brane.core.types.Wei;
+
+/**
+ * JMH benchmark for measuring allocation patterns in transaction RLP encoding.
+ *
+ * <p>Isolates the RLP encoding cost from signing by using a pre-computed signature.
+ * This allows measuring the allocation impact of stream operations, array copies,
+ * and BigInteger conversions in the encoding path alone.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(1)
+public class TxEncodeAllocationBenchmark {
+
+    private LegacyTransaction legacyTx;
+    private Eip1559Transaction eip1559Tx;
+    private Signature signature;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        Address to = new Address("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
+
+        legacyTx = new LegacyTransaction(
+                0,
+                Wei.of(1000000000),
+                21000,
+                to,
+                Wei.of(1),
+                HexData.EMPTY);
+
+        eip1559Tx = new Eip1559Transaction(
+                11155111,
+                0,
+                Wei.of(1000000000),
+                Wei.of(2000000000),
+                21000,
+                to,
+                Wei.of(1),
+                HexData.EMPTY,
+                List.of());
+
+        // Pre-computed signature (valid structure, used only for encoding measurement)
+        byte[] r = new byte[32];
+        byte[] s = new byte[32];
+        r[0] = 0x7f; // Ensure non-zero for realistic encoding
+        r[31] = 0x01;
+        s[0] = 0x3f;
+        s[31] = 0x02;
+        signature = new Signature(r, s, 1);
+    }
+
+    /**
+     * Benchmarks RLP encoding of a legacy transaction for signing.
+     * Measures allocation from RLP list construction and BigInteger encoding.
+     *
+     * @return the RLP-encoded bytes (for blackhole consumption)
+     */
+    @Benchmark
+    public byte[] encodeLegacyForSigning() {
+        return legacyTx.encodeForSigning(31337);
+    }
+
+    /**
+     * Benchmarks RLP encoding of an EIP-1559 transaction for signing.
+     * Measures allocation from RLP list construction and BigInteger encoding.
+     *
+     * @return the RLP-encoded bytes (for blackhole consumption)
+     */
+    @Benchmark
+    public byte[] encodeEip1559ForSigning() {
+        return eip1559Tx.encodeForSigning(11155111);
+    }
+
+    /**
+     * Benchmarks RLP encoding of a signed legacy transaction envelope.
+     * Measures allocation from Signature.r()/s() defensive copies + BigInteger wrapping.
+     *
+     * @return the RLP-encoded envelope bytes (for blackhole consumption)
+     */
+    @Benchmark
+    public byte[] encodeLegacyEnvelope() {
+        return legacyTx.encodeAsEnvelope(signature);
+    }
+
+    /**
+     * Benchmarks RLP encoding of a signed EIP-1559 transaction envelope.
+     * Measures allocation from Signature.r()/s() defensive copies + BigInteger wrapping.
+     *
+     * @return the RLP-encoded envelope bytes (for blackhole consumption)
+     */
+    @Benchmark
+    public byte[] encodeEip1559Envelope() {
+        return eip1559Tx.encodeAsEnvelope(signature);
+    }
+}

--- a/brane-core/src/main/java/sh/brane/core/abi/Bytes.java
+++ b/brane-core/src/main/java/sh/brane/core/abi/Bytes.java
@@ -58,4 +58,16 @@ public record Bytes(HexData value, boolean isDynamic) implements DynamicAbiType 
     public static Bytes ofStatic(byte[] data) {
         return new Bytes(new HexData(sh.brane.primitives.Hex.encode(data)), false);
     }
+
+    /**
+     * Creates a static bytesN type from a sub-range of a byte array without copying.
+     *
+     * @param data   the source byte array
+     * @param offset the starting offset
+     * @param length the number of bytes (1-32)
+     * @return a new static Bytes instance
+     */
+    public static Bytes ofStatic(byte[] data, int offset, int length) {
+        return new Bytes(new HexData(sh.brane.primitives.Hex.encode(data, offset, length)), false);
+    }
 }

--- a/brane-core/src/main/java/sh/brane/core/abi/FastAbiEncoder.java
+++ b/brane-core/src/main/java/sh/brane/core/abi/FastAbiEncoder.java
@@ -4,6 +4,7 @@ package sh.brane.core.abi;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -96,9 +97,10 @@ public final class FastAbiEncoder {
             throw new IllegalArgumentException("Selector must be exactly 4 bytes, got " + selector.length);
         }
         buffer.put(selector);
-        List<AbiType> abiArgs = Arrays.stream(args)
-                .map(arg -> (AbiType) arg)
-                .toList();
+        List<AbiType> abiArgs = new ArrayList<>(args.length);
+        for (Object arg : args) {
+            abiArgs.add((AbiType) arg);
+        }
         encodeTuple(abiArgs, buffer);
     }
 

--- a/brane-core/src/main/java/sh/brane/core/abi/InternalAbi.java
+++ b/brane-core/src/main/java/sh/brane/core/abi/InternalAbi.java
@@ -954,7 +954,7 @@ final class InternalAbi implements Abi {
             throw new AbiDecodingException("Unknown event '" + eventName + "'");
         }
 
-        final List<T> decoded = new ArrayList<>();
+        final List<T> decoded = new ArrayList<>(logs.size());
         for (sh.brane.core.model.LogEntry log : logs) {
             for (AbiEvent event : matching) {
                 if (!matchesEvent(event, log)) {
@@ -1024,7 +1024,7 @@ final class InternalAbi implements Abi {
         final List<Object> values = new ArrayList<>(params.size());
 
         int topicIdx = 1;
-        final List<TypeSchema> nonIndexedSchemas = new ArrayList<>();
+        final List<TypeSchema> nonIndexedSchemas = new ArrayList<>(params.size());
         for (AbiParameter param : params) {
             if (param.indexed) {
                 if (log.topics().size() <= topicIdx) {
@@ -1146,7 +1146,7 @@ final class InternalAbi implements Abi {
             case Utf8String s -> s.value();
             case Bytes bytes -> bytes.value();
             case Array<?> array -> {
-                final List<Object> list = new ArrayList<>();
+                final List<Object> list = new ArrayList<>(array.values().size());
                 for (AbiType t : array.values()) {
                     list.add(toJavaValue(t));
                 }
@@ -1155,7 +1155,7 @@ final class InternalAbi implements Abi {
             case UInt u -> u.value();
             case Int i -> i.value();
             case Tuple t -> {
-                final List<Object> list = new ArrayList<>();
+                final List<Object> list = new ArrayList<>(t.components().size());
                 for (AbiType c : t.components()) {
                     list.add(toJavaValue(c));
                 }
@@ -1175,7 +1175,7 @@ final class InternalAbi implements Abi {
             if (param.components == null || param.components.isEmpty()) {
                 throw new AbiEncodingException("Tuple missing components");
             }
-            List<TypeSchema> componentSchemas = new ArrayList<>();
+            List<TypeSchema> componentSchemas = new ArrayList<>(param.components.size());
             for (AbiParameter component : param.components) {
                 componentSchemas.add(toTypeSchema(component));
             }
@@ -1245,7 +1245,7 @@ final class InternalAbi implements Abi {
                     return null;
                 }
 
-                final List<TypeSchema> schemas = new ArrayList<>();
+                final List<TypeSchema> schemas = new ArrayList<>(abiFunction.outputs().size());
                 for (AbiParameter param : abiFunction.outputs()) {
                     schemas.add(toTypeSchema(param));
                 }

--- a/brane-core/src/main/java/sh/brane/core/crypto/PrivateKey.java
+++ b/brane-core/src/main/java/sh/brane/core/crypto/PrivateKey.java
@@ -213,8 +213,8 @@ public final class PrivateKey implements Destroyable {
             throw new IllegalArgumentException("Message hash must be 32 bytes");
         }
 
-        final BigInteger r = new BigInteger(1, signature.r());
-        final BigInteger s = new BigInteger(1, signature.s());
+        final BigInteger r = signature.rAsBigInteger();
+        final BigInteger s = signature.sAsBigInteger();
 
         // Get recovery ID from signature (handles both simple v and EIP-155 v)
         final int recoveryId;

--- a/brane-core/src/main/java/sh/brane/core/crypto/Signature.java
+++ b/brane-core/src/main/java/sh/brane/core/crypto/Signature.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 package sh.brane.core.crypto;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -90,6 +91,30 @@ public record Signature(byte[] r, byte[] s, int v) {
     @Override
     public byte[] s() {
         return Arrays.copyOf(s, s.length);
+    }
+
+    /**
+     * Returns the r component as a positive BigInteger.
+     * <p>
+     * This avoids the 32-byte defensive copy from {@link #r()} when the caller
+     * only needs a BigInteger (e.g., for RLP encoding in transaction serialization).
+     *
+     * @return r as unsigned BigInteger
+     */
+    public BigInteger rAsBigInteger() {
+        return new BigInteger(1, r);
+    }
+
+    /**
+     * Returns the s component as a positive BigInteger.
+     * <p>
+     * This avoids the 32-byte defensive copy from {@link #s()} when the caller
+     * only needs a BigInteger (e.g., for RLP encoding in transaction serialization).
+     *
+     * @return s as unsigned BigInteger
+     */
+    public BigInteger sAsBigInteger() {
+        return new BigInteger(1, s);
     }
 
     /**

--- a/brane-core/src/main/java/sh/brane/core/tx/Eip1559Transaction.java
+++ b/brane-core/src/main/java/sh/brane/core/tx/Eip1559Transaction.java
@@ -169,8 +169,8 @@ public record Eip1559Transaction(
                         "EIP-1559 signature v must be yParity (0 or 1), got: " + yParity);
             }
             items.add(RlpNumeric.encodeLongUnsignedItem(yParity));
-            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.r())));
-            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.s())));
+            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.rAsBigInteger()));
+            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.sAsBigInteger()));
         }
 
         return Rlp.encodeList(items);

--- a/brane-core/src/main/java/sh/brane/core/tx/Eip1559Transaction.java
+++ b/brane-core/src/main/java/sh/brane/core/tx/Eip1559Transaction.java
@@ -10,7 +10,6 @@ import sh.brane.core.model.AccessListEntry;
 import sh.brane.core.types.Address;
 import sh.brane.core.types.HexData;
 import sh.brane.core.types.Wei;
-import sh.brane.primitives.Hex;
 import sh.brane.primitives.rlp.Rlp;
 import sh.brane.primitives.rlp.RlpItem;
 import sh.brane.primitives.rlp.RlpList;
@@ -194,9 +193,7 @@ public record Eip1559Transaction(
             // Encode storage keys
             final List<RlpItem> storageKeys = new ArrayList<>(entry.storageKeys().size());
             for (sh.brane.core.types.Hash key : entry.storageKeys()) {
-                // Storage keys are 32-byte hashes
-                final byte[] keyBytes = Hex.decode(key.value());
-                storageKeys.add(new RlpString(keyBytes));
+                storageKeys.add(new RlpString(key.toBytes()));
             }
             entryItems.add(new RlpList(storageKeys));
 

--- a/brane-core/src/main/java/sh/brane/core/tx/Eip4844Transaction.java
+++ b/brane-core/src/main/java/sh/brane/core/tx/Eip4844Transaction.java
@@ -233,8 +233,8 @@ public record Eip4844Transaction(
                     "EIP-4844 signature v must be yParity (0 or 1), got: " + yParity);
         }
         signedTxItems.add(RlpNumeric.encodeLongUnsignedItem(yParity));
-        signedTxItems.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.r())));
-        signedTxItems.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.s())));
+        signedTxItems.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.rAsBigInteger()));
+        signedTxItems.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.sAsBigInteger()));
 
         // Build outer list: [signedTxList, blobs, commitments, proofs]
         final List<RlpItem> outerItems = new ArrayList<>(4);
@@ -323,8 +323,8 @@ public record Eip4844Transaction(
                         "EIP-4844 signature v must be yParity (0 or 1), got: " + yParity);
             }
             items.add(RlpNumeric.encodeLongUnsignedItem(yParity));
-            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.r())));
-            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.s())));
+            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.rAsBigInteger()));
+            items.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.sAsBigInteger()));
         }
 
         return Rlp.encodeList(items);

--- a/brane-core/src/main/java/sh/brane/core/tx/Eip4844Transaction.java
+++ b/brane-core/src/main/java/sh/brane/core/tx/Eip4844Transaction.java
@@ -16,7 +16,6 @@ import sh.brane.core.types.HexData;
 import sh.brane.core.types.KzgCommitment;
 import sh.brane.core.types.KzgProof;
 import sh.brane.core.types.Wei;
-import sh.brane.primitives.Hex;
 import sh.brane.primitives.rlp.Rlp;
 import sh.brane.primitives.rlp.RlpItem;
 import sh.brane.primitives.rlp.RlpList;
@@ -285,7 +284,11 @@ public record Eip4844Transaction(
      * @return RLP list of bytes
      */
     private static <T> RlpItem encodeBytesList(List<T> items, Function<T, byte[]> extractor) {
-        return new RlpList(items.stream().<RlpItem>map(item -> new RlpString(extractor.apply(item))).toList());
+        List<RlpItem> rlpItems = new ArrayList<>(items.size());
+        for (T item : items) {
+            rlpItems.add(new RlpString(extractor.apply(item)));
+        }
+        return new RlpList(rlpItems);
     }
 
     /**
@@ -348,9 +351,7 @@ public record Eip4844Transaction(
             // Encode storage keys
             final List<RlpItem> storageKeys = new ArrayList<>(entry.storageKeys().size());
             for (Hash key : entry.storageKeys()) {
-                // Storage keys are 32-byte hashes
-                final byte[] keyBytes = Hex.decode(key.value());
-                storageKeys.add(new RlpString(keyBytes));
+                storageKeys.add(new RlpString(key.toBytes()));
             }
             entryItems.add(new RlpList(storageKeys));
 
@@ -366,8 +367,10 @@ public record Eip4844Transaction(
      * @return RLP list of versioned hashes
      */
     private RlpItem encodeBlobVersionedHashes() {
-        return new RlpList(blobVersionedHashes.stream()
-                .<RlpItem>map(hash -> new RlpString(hash.toBytes()))
-                .toList());
+        List<RlpItem> items = new ArrayList<>(blobVersionedHashes.size());
+        for (var hash : blobVersionedHashes) {
+            items.add(new RlpString(hash.toBytes()));
+        }
+        return new RlpList(items);
     }
 }

--- a/brane-core/src/main/java/sh/brane/core/tx/LegacyTransaction.java
+++ b/brane-core/src/main/java/sh/brane/core/tx/LegacyTransaction.java
@@ -145,8 +145,8 @@ public record LegacyTransaction(
 
         // Add signature components (v is already EIP-155 encoded)
         items.add(RlpNumeric.encodeLongUnsignedItem(signature.v()));
-        items.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.r())));
-        items.add(RlpNumeric.encodeBigIntegerUnsignedItem(new java.math.BigInteger(1, signature.s())));
+        items.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.rAsBigInteger()));
+        items.add(RlpNumeric.encodeBigIntegerUnsignedItem(signature.sAsBigInteger()));
 
         return Rlp.encodeList(items);
     }

--- a/brane-core/src/test/java/sh/brane/core/abi/BytesTest.java
+++ b/brane-core/src/test/java/sh/brane/core/abi/BytesTest.java
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.core.abi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the Bytes ABI type, focusing on the ofStatic subarray factory.
+ */
+class BytesTest {
+
+    @Test
+    void testOfStaticSubarrayMatchesFullArray() {
+        byte[] data = new byte[] {0x00, 0x11, 0x22, 0x33, 0x44};
+
+        // ofStatic(subarray) should match ofStatic(extracted copy)
+        Bytes fromSubarray = Bytes.ofStatic(data, 1, 3);
+        Bytes fromCopy = Bytes.ofStatic(new byte[] {0x11, 0x22, 0x33});
+
+        assertEquals(fromCopy.value(), fromSubarray.value());
+        assertFalse(fromSubarray.isDynamic());
+    }
+
+    @Test
+    void testOfStaticSubarraySingleByte() {
+        byte[] data = new byte[] {(byte) 0xFF, 0x42, 0x00};
+
+        Bytes result = Bytes.ofStatic(data, 1, 1);
+
+        assertEquals("0x42", result.value().value());
+        assertFalse(result.isDynamic());
+        assertEquals("bytes1", result.typeName());
+    }
+
+    @Test
+    void testOfStaticSubarray32Bytes() {
+        byte[] data = new byte[34];
+        // Fill bytes 1..32 with a pattern
+        for (int i = 0; i < 32; i++) {
+            data[i + 1] = (byte) i;
+        }
+
+        Bytes result = Bytes.ofStatic(data, 1, 32);
+
+        assertFalse(result.isDynamic());
+        assertEquals("bytes32", result.typeName());
+        assertEquals(32, result.value().byteLength());
+    }
+
+    @Test
+    void testOfStaticSubarrayAtEnd() {
+        byte[] data = new byte[] {0x00, 0x00, (byte) 0xAB, (byte) 0xCD};
+
+        Bytes result = Bytes.ofStatic(data, 2, 2);
+
+        assertEquals("0xabcd", result.value().value());
+        assertFalse(result.isDynamic());
+    }
+
+    @Test
+    void testOfStaticSubarrayRejectsZeroLength() {
+        byte[] data = new byte[] {0x01, 0x02};
+
+        // Static bytes must be 1-32 bytes; zero length is invalid
+        assertThrows(IllegalArgumentException.class, () -> Bytes.ofStatic(data, 0, 0));
+    }
+
+    @Test
+    void testOfStaticSubarrayRejectsOver32Bytes() {
+        byte[] data = new byte[64];
+
+        // Static bytes max is 32
+        assertThrows(IllegalArgumentException.class, () -> Bytes.ofStatic(data, 0, 33));
+    }
+}

--- a/brane-primitives/src/main/java/sh/brane/primitives/Hex.java
+++ b/brane-primitives/src/main/java/sh/brane/primitives/Hex.java
@@ -2,6 +2,7 @@
 package sh.brane.primitives;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Utility methods for hex encoding/decoding with optional {@code 0x} prefixes.
@@ -398,15 +399,7 @@ public final class Hex {
         if (bytes == null) {
             throw new IllegalArgumentException("bytes cannot be null");
         }
-        if (offset < 0) {
-            throw new IllegalArgumentException("offset cannot be negative: " + offset);
-        }
-        if (length < 0) {
-            throw new IllegalArgumentException("length cannot be negative: " + length);
-        }
-        if (offset + length > bytes.length) {
-            throw new IllegalArgumentException(
-                    "range out of bounds: offset=" + offset + ", length=" + length + ", bytes.length=" + bytes.length);
-        }
+        // Overflow-safe bounds check (JVM intrinsic, Java 16+)
+        Objects.checkFromIndexSize(offset, length, bytes.length);
     }
 }

--- a/brane-primitives/src/main/java/sh/brane/primitives/Hex.java
+++ b/brane-primitives/src/main/java/sh/brane/primitives/Hex.java
@@ -115,6 +115,58 @@ public final class Hex {
     }
 
     /**
+     * Convert a sub-range of a byte array into a lowercase hex string with a {@code 0x} prefix.
+     *
+     * <p><b>Allocation:</b> 2 allocations (char[] + String). Avoids copying the sub-range
+     * into a temporary byte array.
+     *
+     * @param bytes  the source byte array
+     * @param offset the starting offset in the byte array
+     * @param length the number of bytes to encode
+     * @return hex string with {@code 0x} prefix
+     * @throws IllegalArgumentException if {@code bytes} is {@code null},
+     *                                  or if offset/length are out of bounds
+     */
+    public static String encode(final byte[] bytes, final int offset, final int length) {
+        validateSubarray(bytes, offset, length);
+
+        final char[] chars = new char[2 + length * 2];
+        chars[0] = '0';
+        chars[1] = 'x';
+        for (int i = 0; i < length; i++) {
+            final int v = bytes[offset + i] & 0xFF;
+            chars[2 + i * 2] = HEX_CHARS[v >>> 4];
+            chars[2 + i * 2 + 1] = HEX_CHARS[v & 0x0F];
+        }
+        return new String(chars);
+    }
+
+    /**
+     * Convert a sub-range of a byte array into a lowercase hex string without a {@code 0x} prefix.
+     *
+     * <p><b>Allocation:</b> 1 allocation (char[] converted to String). Avoids copying the
+     * sub-range into a temporary byte array.
+     *
+     * @param bytes  the source byte array
+     * @param offset the starting offset in the byte array
+     * @param length the number of bytes to encode
+     * @return hex string without {@code 0x} prefix
+     * @throws IllegalArgumentException if {@code bytes} is {@code null},
+     *                                  or if offset/length are out of bounds
+     */
+    public static String encodeNoPrefix(final byte[] bytes, final int offset, final int length) {
+        validateSubarray(bytes, offset, length);
+
+        final char[] chars = new char[length * 2];
+        for (int i = 0; i < length; i++) {
+            final int v = bytes[offset + i] & 0xFF;
+            chars[i * 2] = HEX_CHARS[v >>> 4];
+            chars[i * 2 + 1] = HEX_CHARS[v & 0x0F];
+        }
+        return new String(chars);
+    }
+
+    /**
      * Convert a byte array into a lowercase hex string without a {@code 0x} prefix.
      *
      * @param bytes the bytes to encode
@@ -340,5 +392,21 @@ public final class Hex {
             throw new IllegalArgumentException("invalid hex character in: " + originalInput);
         }
         return NIBBLE_LOOKUP[c];
+    }
+
+    private static void validateSubarray(final byte[] bytes, final int offset, final int length) {
+        if (bytes == null) {
+            throw new IllegalArgumentException("bytes cannot be null");
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset cannot be negative: " + offset);
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("length cannot be negative: " + length);
+        }
+        if (offset + length > bytes.length) {
+            throw new IllegalArgumentException(
+                    "range out of bounds: offset=" + offset + ", length=" + length + ", bytes.length=" + bytes.length);
+        }
     }
 }

--- a/brane-primitives/src/test/java/sh/brane/primitives/HexTest.java
+++ b/brane-primitives/src/test/java/sh/brane/primitives/HexTest.java
@@ -506,6 +506,113 @@ class HexTest {
         assertThrows(IllegalArgumentException.class, () -> Hex.decodeTo("0x 1", 0, 4, dest, 0)); // space
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // Subarray encode tests: Hex.encode(byte[], int, int) and
+    // Hex.encodeNoPrefix(byte[], int, int)
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("encode subarray encodes middle portion with 0x prefix")
+    void testEncodeSubarray() {
+        byte[] bytes = new byte[] {0x00, 0x11, 0x22, 0x33, 0x44};
+        assertEquals("0x112233", Hex.encode(bytes, 1, 3));
+    }
+
+    @Test
+    @DisplayName("encode subarray encodes full array when offset=0 and length=array.length")
+    void testEncodeSubarrayFullArray() {
+        byte[] bytes = new byte[] {0x0A, (byte) 0xBC};
+        assertEquals("0x0abc", Hex.encode(bytes, 0, 2));
+        assertEquals(Hex.encode(bytes), Hex.encode(bytes, 0, bytes.length));
+    }
+
+    @Test
+    @DisplayName("encode subarray handles zero-length range")
+    void testEncodeSubarrayZeroLength() {
+        byte[] bytes = new byte[] {0x01, 0x02};
+        assertEquals("0x", Hex.encode(bytes, 0, 0));
+        assertEquals("0x", Hex.encode(bytes, 1, 0));
+    }
+
+    @Test
+    @DisplayName("encode subarray handles single byte")
+    void testEncodeSubarraySingleByte() {
+        byte[] bytes = new byte[] {0x00, (byte) 0xFF, 0x42};
+        assertEquals("0xff", Hex.encode(bytes, 1, 1));
+        assertEquals("0x42", Hex.encode(bytes, 2, 1));
+    }
+
+    @Test
+    @DisplayName("encode subarray at end of array")
+    void testEncodeSubarrayEnd() {
+        byte[] bytes = new byte[] {0x00, 0x11, 0x22, 0x33};
+        assertEquals("0x2233", Hex.encode(bytes, 2, 2));
+    }
+
+    @Test
+    @DisplayName("encodeNoPrefix subarray encodes without 0x prefix")
+    void testEncodeNoPrefixSubarray() {
+        byte[] bytes = new byte[] {0x00, 0x11, 0x22, 0x33, 0x44};
+        assertEquals("112233", Hex.encodeNoPrefix(bytes, 1, 3));
+    }
+
+    @Test
+    @DisplayName("encodeNoPrefix subarray full array matches encodeNoPrefix(byte[])")
+    void testEncodeNoPrefixSubarrayFullArray() {
+        byte[] bytes = new byte[] {0x0A, (byte) 0xBC};
+        assertEquals("0abc", Hex.encodeNoPrefix(bytes, 0, 2));
+        assertEquals(Hex.encodeNoPrefix(bytes), Hex.encodeNoPrefix(bytes, 0, bytes.length));
+    }
+
+    @Test
+    @DisplayName("encodeNoPrefix subarray handles zero-length range")
+    void testEncodeNoPrefixSubarrayZeroLength() {
+        byte[] bytes = new byte[] {0x01};
+        assertEquals("", Hex.encodeNoPrefix(bytes, 0, 0));
+    }
+
+    @Test
+    @DisplayName("encode subarray rejects null bytes")
+    void testEncodeSubarrayNullBytes() {
+        assertThrows(IllegalArgumentException.class, () -> Hex.encode(null, 0, 1));
+        assertThrows(IllegalArgumentException.class, () -> Hex.encodeNoPrefix(null, 0, 1));
+    }
+
+    @Test
+    @DisplayName("encode subarray rejects negative offset")
+    void testEncodeSubarrayNegativeOffset() {
+        byte[] bytes = new byte[] {0x01};
+        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, -1, 1));
+        assertThrows(IllegalArgumentException.class, () -> Hex.encodeNoPrefix(bytes, -1, 1));
+    }
+
+    @Test
+    @DisplayName("encode subarray rejects negative length")
+    void testEncodeSubarrayNegativeLength() {
+        byte[] bytes = new byte[] {0x01};
+        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, 0, -1));
+        assertThrows(IllegalArgumentException.class, () -> Hex.encodeNoPrefix(bytes, 0, -1));
+    }
+
+    @Test
+    @DisplayName("encode subarray rejects out-of-bounds range")
+    void testEncodeSubarrayOutOfBounds() {
+        byte[] bytes = new byte[] {0x01, 0x02};
+        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, 1, 2));
+        assertThrows(IllegalArgumentException.class, () -> Hex.encodeNoPrefix(bytes, 1, 2));
+        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, 3, 0));
+    }
+
+    @Test
+    @DisplayName("encode subarray round-trip with decode")
+    void testEncodeSubarrayRoundTrip() {
+        byte[] bytes = new byte[] {0x00, 0x7F, (byte) 0x80, (byte) 0xFF, 0x42};
+        // Encode middle 3 bytes, decode, verify
+        String hex = Hex.encode(bytes, 1, 3);
+        byte[] decoded = Hex.decode(hex);
+        assertArrayEquals(new byte[] {0x7F, (byte) 0x80, (byte) 0xFF}, decoded);
+    }
+
     @Test
     @DisplayName("decodeTo round-trip with encodeTo")
     void testDecodeToRoundTrip() {

--- a/brane-primitives/src/test/java/sh/brane/primitives/HexTest.java
+++ b/brane-primitives/src/test/java/sh/brane/primitives/HexTest.java
@@ -582,25 +582,25 @@ class HexTest {
     @DisplayName("encode subarray rejects negative offset")
     void testEncodeSubarrayNegativeOffset() {
         byte[] bytes = new byte[] {0x01};
-        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, -1, 1));
-        assertThrows(IllegalArgumentException.class, () -> Hex.encodeNoPrefix(bytes, -1, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> Hex.encode(bytes, -1, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> Hex.encodeNoPrefix(bytes, -1, 1));
     }
 
     @Test
     @DisplayName("encode subarray rejects negative length")
     void testEncodeSubarrayNegativeLength() {
         byte[] bytes = new byte[] {0x01};
-        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, 0, -1));
-        assertThrows(IllegalArgumentException.class, () -> Hex.encodeNoPrefix(bytes, 0, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> Hex.encode(bytes, 0, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> Hex.encodeNoPrefix(bytes, 0, -1));
     }
 
     @Test
     @DisplayName("encode subarray rejects out-of-bounds range")
     void testEncodeSubarrayOutOfBounds() {
         byte[] bytes = new byte[] {0x01, 0x02};
-        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, 1, 2));
-        assertThrows(IllegalArgumentException.class, () -> Hex.encodeNoPrefix(bytes, 1, 2));
-        assertThrows(IllegalArgumentException.class, () -> Hex.encode(bytes, 3, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> Hex.encode(bytes, 1, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> Hex.encodeNoPrefix(bytes, 1, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> Hex.encode(bytes, 3, 0));
     }
 
     @Test

--- a/brane-rpc/src/main/java/sh/brane/rpc/internal/RpcUtils.java
+++ b/brane-rpc/src/main/java/sh/brane/rpc/internal/RpcUtils.java
@@ -4,6 +4,7 @@ package sh.brane.rpc.internal;
 import java.lang.reflect.Array;
 import java.math.BigInteger;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -288,15 +289,18 @@ public final class RpcUtils {
      * @return list of maps suitable for JSON-RPC serialization
      */
     public static List<Map<String, Object>> toJsonAccessList(final List<AccessListEntry> entries) {
-        return entries.stream()
-                .map(entry -> {
-                    // Explicit type required: var would infer LinkedHashMap, causing List<Map> incompatibility
-                    final Map<String, Object> map = new LinkedHashMap<>();
-                    map.put("address", entry.address().value());
-                    map.put("storageKeys", entry.storageKeys().stream().map(Hash::value).toList());
-                    return map;
-                })
-                .toList();
+        List<Map<String, Object>> result = new ArrayList<>(entries.size());
+        for (AccessListEntry entry : entries) {
+            final Map<String, Object> map = new LinkedHashMap<>();
+            map.put("address", entry.address().value());
+            List<String> keys = new ArrayList<>(entry.storageKeys().size());
+            for (Hash key : entry.storageKeys()) {
+                keys.add(key.value());
+            }
+            map.put("storageKeys", keys);
+            result.add(map);
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Eliminate `Arrays.copyOfRange` in ABI decoder using subarray constructors (`BigInteger`, `String`, `Hex.encode`)
- Replace `stream().map().toList()` with pre-sized `ArrayList` loops on allocation-sensitive paths (FastAbiEncoder, tx encoding, EIP-712, RpcUtils)
- Replace `ByteArrayOutputStream` with fixed `byte[]` buffers in TypedDataEncoder
- Add `Signature.rAsBigInteger()/sAsBigInteger()` to skip defensive copies in tx serialization
- Add `Hex.encode(byte[], int, int)` subarray overload and `Bytes.ofStatic(byte[], int, int)` factory
- Use `Objects.checkFromIndexSize` for overflow-safe bounds checking in Hex

## Measured savings (JMH `-prof gc`)

| Path | Before | After | Savings |
|------|--------|-------|---------|
| ABI decode uint256 | 184 B/op | 136 B/op | -48 B |
| ABI encode complex nested | 5,280 B/op | 4,744 B/op | -536 B |
| Tx encode (per tx) | — | — | -64 B (Signature alone) |

No throughput regressions. No API breaks.

## Test plan

- [x] Unit tests for all new public API methods (Hex subarray, Signature BigInteger, Bytes subarray)
- [x] `./verify_all.sh` passes (unit + integration + smoke)
- [x] JMH allocation benchmarks confirm savings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/noise-xyz/brane/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
