### PR TITLE
docs: fix @throws Javadoc for subarray methods

### DIFF
--- a/brane-core/src/main/java/sh/brane/core/abi/Bytes.java
+++ b/brane-core/src/main/java/sh/brane/core/abi/Bytes.java
@@ -66,6 +66,8 @@ public record Bytes(HexData value, boolean isDynamic) implements DynamicAbiType 
      * @param offset the starting offset
      * @param length the number of bytes (1-32)
      * @return a new static Bytes instance
+     * @throws IllegalArgumentException if {@code data} is {@code null} or length is not 1-32
+     * @throws IndexOutOfBoundsException if offset/length are out of bounds
      */
     public static Bytes ofStatic(byte[] data, int offset, int length) {
         return new Bytes(new HexData(sh.brane.primitives.Hex.encode(data, offset, length)), false);

--- a/brane-primitives/src/main/java/sh/brane/primitives/Hex.java
+++ b/brane-primitives/src/main/java/sh/brane/primitives/Hex.java
@@ -125,8 +125,8 @@ public final class Hex {
      * @param offset the starting offset in the byte array
      * @param length the number of bytes to encode
      * @return hex string with {@code 0x} prefix
-     * @throws IllegalArgumentException if {@code bytes} is {@code null},
-     *                                  or if offset/length are out of bounds
+     * @throws IllegalArgumentException if {@code bytes} is {@code null}
+     * @throws IndexOutOfBoundsException if offset/length are out of bounds
      */
     public static String encode(final byte[] bytes, final int offset, final int length) {
         validateSubarray(bytes, offset, length);
@@ -152,8 +152,8 @@ public final class Hex {
      * @param offset the starting offset in the byte array
      * @param length the number of bytes to encode
      * @return hex string without {@code 0x} prefix
-     * @throws IllegalArgumentException if {@code bytes} is {@code null},
-     *                                  or if offset/length are out of bounds
+     * @throws IllegalArgumentException if {@code bytes} is {@code null}
+     * @throws IndexOutOfBoundsException if offset/length are out of bounds
      */
     public static String encodeNoPrefix(final byte[] bytes, final int offset, final int length) {
         validateSubarray(bytes, offset, length);


### PR DESCRIPTION
## Summary

- Fix `@throws` Javadoc on `Hex.encode(byte[], int, int)` and `Hex.encodeNoPrefix(byte[], int, int)` to document `IndexOutOfBoundsException` (from `Objects.checkFromIndexSize`) separately from `IllegalArgumentException` (null input)
- Add missing `@throws` to `Bytes.ofStatic(byte[], int, int)`

Follow-up to #103 — these Javadoc fixes were made after the squash merge.

## Test plan

- [x] No code changes, Javadoc only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/noise-xyz/brane/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
