### PR TITLE
feat: EIP-3009 TransferWithAuthorization support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Modern, type-safe Java 21 SDK for Ethereum/EVM. Inspired by viem (TS) and alloy 
 | Module | Purpose | Key Classes |
 |--------|---------|-------------|
 | `brane-primitives` | Hex/RLP utilities (zero deps) | `Hex`, `Rlp` |
-| `brane-core` | Types, ABI, crypto, EIP-712, models | `Address`, `Wei`, `Abi`, `PrivateKey`, `MnemonicWallet`, `TypedData`, `TxBuilder`, `Blob`, `BlobSidecar`, `Eip4844Builder` |
+| `brane-core` | Types, ABI, crypto, EIP-712, EIP-3009, models | `Address`, `Wei`, `Abi`, `PrivateKey`, `MnemonicWallet`, `TypedData`, `Eip3009`, `TxBuilder`, `Blob`, `BlobSidecar`, `Eip4844Builder` |
 | `brane-kzg` | KZG commitments for EIP-4844 blobs | `CKzg`, `Kzg` |
 | `brane-rpc` | JSON-RPC client layer | `Brane`, `Brane.Reader`, `Brane.Signer`, `Brane.Tester`, `BraneProvider` |
 | `brane-contract` | Contract binding (no codegen) | `BraneContract.bind()`, `ReadOnlyContract` |
@@ -136,6 +136,25 @@ Hash hash = typedData.hash();
 
 // JSON parsing (WalletConnect, dapp requests)
 TypedData<?> fromJson = TypedDataJson.parseAndValidate(jsonString);
+```
+
+### EIP-3009 Gasless Token Transfers
+```java
+// USDC domain (name="USD Coin", version="2" across all chains)
+var domain = Eip3009.usdcDomain(8453L, usdcAddress);  // Base mainnet
+
+// Create authorization (auto nonce + 1 hour validity)
+var auth = Eip3009.transferAuthorization(
+    signer.address(), recipient,
+    BigInteger.valueOf(1_000_000),  // 1 USDC
+    3600                            // valid for 1 hour
+);
+
+// Sign and extract v/r/s for on-chain submission
+Signature sig = Eip3009.sign(auth, domain, signer);
+int v = sig.v();
+byte[] r = sig.r();
+byte[] s = sig.s();
 ```
 
 ### Integration Testing with Brane.Tester

--- a/brane-core/src/main/java/sh/brane/core/crypto/eip3009/CancelAuthorization.java
+++ b/brane-core/src/main/java/sh/brane/core/crypto/eip3009/CancelAuthorization.java
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.core.crypto.eip3009;
+
+import sh.brane.core.crypto.eip712.TypeDefinition;
+import sh.brane.core.crypto.eip712.TypedDataField;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.Hash;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import sh.brane.primitives.Hex;
+
+/**
+ * EIP-3009 CancelAuthorization message.
+ *
+ * <p>Allows an authorizer to cancel an outstanding authorization before it is used.
+ * Once canceled, the nonce is permanently consumed and cannot be reused.
+ *
+ * @param authorizer the address that originally signed the authorization
+ * @param nonce      the 32-byte nonce of the authorization to cancel
+ * @see <a href="https://eips.ethereum.org/EIPS/eip-3009">EIP-3009</a>
+ */
+public record CancelAuthorization(
+    Address authorizer,
+    byte[] nonce
+) {
+    /** Length in bytes of the EIP-3009 nonce (bytes32). */
+    private static final int NONCE_LENGTH = 32;
+
+    /**
+     * EIP-712 typehash for CancelAuthorization.
+     *
+     * <p>{@code keccak256("CancelAuthorization(address authorizer,bytes32 nonce)")}
+     */
+    public static final Hash TYPEHASH = new Hash(
+        "0x158b0a9edf7a828aad02f63cd515c68ef2f50ba807396f6d12842833a1597429");
+
+    /** EIP-712 type definition for CancelAuthorization. */
+    public static final TypeDefinition<CancelAuthorization> DEFINITION =
+        TypeDefinition.forRecord(
+            CancelAuthorization.class,
+            "CancelAuthorization",
+            Map.of("CancelAuthorization", List.of(
+                TypedDataField.of("authorizer", "address"),
+                TypedDataField.of("nonce", "bytes32")
+            ))
+        );
+
+    /** Compact constructor — validates all fields and makes defensive copy of nonce. */
+    public CancelAuthorization {
+        Objects.requireNonNull(authorizer, "authorizer");
+        Objects.requireNonNull(nonce, "nonce");
+        if (nonce.length != NONCE_LENGTH) {
+            throw new IllegalArgumentException(
+                "nonce must be " + NONCE_LENGTH + " bytes, got " + nonce.length);
+        }
+        nonce = Arrays.copyOf(nonce, NONCE_LENGTH);
+    }
+
+    /**
+     * Returns the nonce bytes.
+     * <p>A defensive copy is returned to preserve immutability.
+     *
+     * @return a copy of the nonce bytes (32 bytes)
+     */
+    @Override
+    public byte[] nonce() {
+        return Arrays.copyOf(nonce, nonce.length);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof CancelAuthorization other)) return false;
+        return authorizer.equals(other.authorizer)
+            && Arrays.equals(nonce, other.nonce);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authorizer, Arrays.hashCode(nonce));
+    }
+
+    @Override
+    public String toString() {
+        return "CancelAuthorization[authorizer=" + authorizer.value()
+            + ", nonce=0x" + Hex.encodeNoPrefix(nonce) + "]";
+    }
+}

--- a/brane-core/src/main/java/sh/brane/core/crypto/eip3009/Eip3009.java
+++ b/brane-core/src/main/java/sh/brane/core/crypto/eip3009/Eip3009.java
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.core.crypto.eip3009;
+
+import sh.brane.core.crypto.Signature;
+import sh.brane.core.crypto.Signer;
+import sh.brane.core.crypto.eip712.Eip712Domain;
+import sh.brane.core.crypto.eip712.TypedData;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.Hash;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Objects;
+
+/**
+ * EIP-3009 Transfer With Authorization utilities.
+ *
+ * <p>Provides helpers for signing and hashing EIP-3009 authorization messages.
+ * These are the off-chain primitives needed for gasless token transfers
+ * (e.g., USDC via the x402 protocol).
+ *
+ * <p>Example — sign a USDC transfer authorization:
+ * <pre>{@code
+ * var domain = Eip3009.usdcDomain(8453L, usdcAddress);  // Base mainnet
+ *
+ * var auth = Eip3009.transferAuthorization(
+ *     signer.address(),
+ *     recipient,
+ *     BigInteger.valueOf(1_000_000),  // 1 USDC
+ *     3600                            // valid for 1 hour
+ * );
+ *
+ * Signature sig = Eip3009.sign(auth, domain, signer);
+ *
+ * // Extract v/r/s for on-chain submission
+ * int v = sig.v();
+ * byte[] r = sig.r();
+ * byte[] s = sig.s();
+ * }</pre>
+ *
+ * @see <a href="https://eips.ethereum.org/EIPS/eip-3009">EIP-3009</a>
+ */
+public final class Eip3009 {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private Eip3009() {}
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Domain helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * Creates the EIP-712 domain for USDC on the given chain.
+     *
+     * <p>USDC uses domain name {@code "USD Coin"} and version {@code "2"}
+     * across all chains where Circle deploys native USDC.
+     *
+     * @param chainId         the EIP-155 chain ID
+     * @param contractAddress the USDC contract address on this chain
+     * @return the EIP-712 domain
+     * @throws NullPointerException if contractAddress is null
+     */
+    public static Eip712Domain usdcDomain(long chainId, Address contractAddress) {
+        Objects.requireNonNull(contractAddress, "contractAddress");
+        return Eip712Domain.builder()
+            .name("USD Coin")
+            .version("2")
+            .chainId(chainId)
+            .verifyingContract(contractAddress)
+            .build();
+    }
+
+    /**
+     * Creates the EIP-712 domain for EURC on the given chain.
+     *
+     * <p>EURC uses domain name {@code "EURC"} and version {@code "2"}.
+     *
+     * @param chainId         the EIP-155 chain ID
+     * @param contractAddress the EURC contract address on this chain
+     * @return the EIP-712 domain
+     * @throws NullPointerException if contractAddress is null
+     */
+    public static Eip712Domain eurcDomain(long chainId, Address contractAddress) {
+        Objects.requireNonNull(contractAddress, "contractAddress");
+        return Eip712Domain.builder()
+            .name("EURC")
+            .version("2")
+            .chainId(chainId)
+            .verifyingContract(contractAddress)
+            .build();
+    }
+
+    /**
+     * Creates the EIP-712 domain for any EIP-3009 token.
+     *
+     * @param tokenName       the token's EIP-712 domain name (e.g., "USD Coin")
+     * @param version         the token's EIP-712 domain version (e.g., "2")
+     * @param chainId         the chain ID
+     * @param contractAddress the token contract address
+     * @return the EIP-712 domain
+     * @throws NullPointerException if any argument is null
+     */
+    public static Eip712Domain tokenDomain(
+            String tokenName, String version, long chainId, Address contractAddress) {
+        Objects.requireNonNull(tokenName, "tokenName");
+        Objects.requireNonNull(version, "version");
+        Objects.requireNonNull(contractAddress, "contractAddress");
+        return Eip712Domain.builder()
+            .name(tokenName)
+            .version(version)
+            .chainId(chainId)
+            .verifyingContract(contractAddress)
+            .build();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Nonce generation
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * Generates a random 32-byte nonce for EIP-3009 authorization.
+     *
+     * <p>EIP-3009 uses random {@code bytes32} nonces (not sequential),
+     * allowing multiple concurrent authorizations without ordering constraints.
+     *
+     * @return 32 cryptographically random bytes
+     */
+    public static byte[] randomNonce() {
+        var nonce = new byte[32];
+        RANDOM.nextBytes(nonce);
+        return nonce;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Factory methods
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * Creates a TransferAuthorization with explicit timestamps and nonce.
+     *
+     * <p>This is the fully explicit factory — use for deterministic testing
+     * or when you need precise control over the authorization parameters.
+     *
+     * @param from        payer address
+     * @param to          payee address
+     * @param value       token amount in smallest units
+     * @param validAfter  earliest valid timestamp (unix seconds)
+     * @param validBefore latest valid timestamp (unix seconds)
+     * @param nonce       random 32-byte nonce
+     * @return the authorization message
+     */
+    public static TransferAuthorization transferAuthorization(
+            Address from, Address to, BigInteger value,
+            BigInteger validAfter, BigInteger validBefore, byte[] nonce) {
+        return new TransferAuthorization(from, to, value, validAfter, validBefore, nonce);
+    }
+
+    /**
+     * Creates a TransferAuthorization with a random nonce and a validity window.
+     *
+     * <p>Sets {@code validAfter = now - 5s} (clock skew buffer) and
+     * {@code validBefore = now + validForSeconds}. Generates a random nonce.
+     *
+     * @param from            payer address
+     * @param to              payee address
+     * @param value           token amount in smallest units
+     * @param validForSeconds how many seconds from now the authorization is valid
+     * @return the authorization message
+     * @throws NullPointerException if from, to, or value is null
+     */
+    public static TransferAuthorization transferAuthorization(
+            Address from, Address to, BigInteger value, long validForSeconds) {
+        long now = System.currentTimeMillis() / 1000;
+        return new TransferAuthorization(
+            from, to, value,
+            BigInteger.valueOf(now - 5),
+            BigInteger.valueOf(now + validForSeconds),
+            randomNonce()
+        );
+    }
+
+    /**
+     * Creates a ReceiveAuthorization with explicit timestamps and nonce.
+     *
+     * @param from        payer address
+     * @param to          payee address (must be {@code msg.sender} on-chain)
+     * @param value       token amount in smallest units
+     * @param validAfter  earliest valid timestamp (unix seconds)
+     * @param validBefore latest valid timestamp (unix seconds)
+     * @param nonce       random 32-byte nonce
+     * @return the authorization message
+     */
+    public static ReceiveAuthorization receiveAuthorization(
+            Address from, Address to, BigInteger value,
+            BigInteger validAfter, BigInteger validBefore, byte[] nonce) {
+        return new ReceiveAuthorization(from, to, value, validAfter, validBefore, nonce);
+    }
+
+    /**
+     * Creates a ReceiveAuthorization with a random nonce and a validity window.
+     *
+     * <p>Sets {@code validAfter = now - 5s} (clock skew buffer) and
+     * {@code validBefore = now + validForSeconds}. Generates a random nonce.
+     *
+     * @param from            payer address
+     * @param to              payee address (must be {@code msg.sender} on-chain)
+     * @param value           token amount in smallest units
+     * @param validForSeconds how many seconds from now the authorization is valid
+     * @return the authorization message
+     * @throws NullPointerException if from, to, or value is null
+     */
+    public static ReceiveAuthorization receiveAuthorization(
+            Address from, Address to, BigInteger value, long validForSeconds) {
+        long now = System.currentTimeMillis() / 1000;
+        return new ReceiveAuthorization(
+            from, to, value,
+            BigInteger.valueOf(now - 5),
+            BigInteger.valueOf(now + validForSeconds),
+            randomNonce()
+        );
+    }
+
+    /**
+     * Creates a CancelAuthorization with an explicit nonce.
+     *
+     * @param authorizer the address that originally signed the authorization
+     * @param nonce      the 32-byte nonce of the authorization to cancel
+     * @return the cancel authorization message
+     */
+    public static CancelAuthorization cancelAuthorization(Address authorizer, byte[] nonce) {
+        return new CancelAuthorization(authorizer, nonce);
+    }
+
+    /**
+     * Creates a CancelAuthorization with a random nonce.
+     *
+     * @param authorizer the address that originally signed the authorization
+     * @return the cancel authorization message with a random nonce
+     * @throws NullPointerException if authorizer is null
+     */
+    public static CancelAuthorization cancelAuthorization(Address authorizer) {
+        return new CancelAuthorization(authorizer, randomNonce());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Signing
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * Signs a TransferWithAuthorization message.
+     *
+     * @param auth   the authorization message
+     * @param domain the token's EIP-712 domain
+     * @param signer the signer (must be the {@code from} address)
+     * @return signature with v=27 or v=28
+     * @throws NullPointerException if any argument is null
+     */
+    public static Signature sign(TransferAuthorization auth, Eip712Domain domain, Signer signer) {
+        return TypedData.create(domain, TransferAuthorization.DEFINITION, auth).sign(signer);
+    }
+
+    /**
+     * Signs a ReceiveWithAuthorization message.
+     *
+     * @param auth   the authorization message
+     * @param domain the token's EIP-712 domain
+     * @param signer the signer (must be the {@code from} address)
+     * @return signature with v=27 or v=28
+     * @throws NullPointerException if any argument is null
+     */
+    public static Signature sign(ReceiveAuthorization auth, Eip712Domain domain, Signer signer) {
+        return TypedData.create(domain, ReceiveAuthorization.DEFINITION, auth).sign(signer);
+    }
+
+    /**
+     * Signs a CancelAuthorization message.
+     *
+     * @param auth   the cancel authorization message
+     * @param domain the token's EIP-712 domain
+     * @param signer the signer (must be the {@code authorizer} address)
+     * @return signature with v=27 or v=28
+     * @throws NullPointerException if any argument is null
+     */
+    public static Signature sign(CancelAuthorization auth, Eip712Domain domain, Signer signer) {
+        return TypedData.create(domain, CancelAuthorization.DEFINITION, auth).sign(signer);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Hashing
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * Computes the EIP-712 hash for a TransferWithAuthorization without signing.
+     *
+     * @param auth   the authorization message
+     * @param domain the token's EIP-712 domain
+     * @return the 32-byte EIP-712 signing hash
+     */
+    public static Hash hash(TransferAuthorization auth, Eip712Domain domain) {
+        return TypedData.create(domain, TransferAuthorization.DEFINITION, auth).hash();
+    }
+
+    /**
+     * Computes the EIP-712 hash for a ReceiveWithAuthorization without signing.
+     *
+     * @param auth   the authorization message
+     * @param domain the token's EIP-712 domain
+     * @return the 32-byte EIP-712 signing hash
+     */
+    public static Hash hash(ReceiveAuthorization auth, Eip712Domain domain) {
+        return TypedData.create(domain, ReceiveAuthorization.DEFINITION, auth).hash();
+    }
+
+    /**
+     * Computes the EIP-712 hash for a CancelAuthorization without signing.
+     *
+     * @param auth   the cancel authorization message
+     * @param domain the token's EIP-712 domain
+     * @return the 32-byte EIP-712 signing hash
+     */
+    public static Hash hash(CancelAuthorization auth, Eip712Domain domain) {
+        return TypedData.create(domain, CancelAuthorization.DEFINITION, auth).hash();
+    }
+}

--- a/brane-core/src/main/java/sh/brane/core/crypto/eip3009/ReceiveAuthorization.java
+++ b/brane-core/src/main/java/sh/brane/core/crypto/eip3009/ReceiveAuthorization.java
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.core.crypto.eip3009;
+
+import sh.brane.core.crypto.eip712.TypeDefinition;
+import sh.brane.core.crypto.eip712.TypedDataField;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.Hash;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import sh.brane.primitives.Hex;
+
+/**
+ * EIP-3009 ReceiveWithAuthorization message.
+ *
+ * <p>Similar to {@link TransferAuthorization} but requires {@code msg.sender == to},
+ * preventing front-running by ensuring only the intended recipient can submit
+ * the authorization on-chain.
+ *
+ * @param from        the payer address
+ * @param to          the payee address (must be {@code msg.sender} on-chain)
+ * @param value       the transfer amount in token smallest units
+ * @param validAfter  earliest timestamp (unix seconds) when authorization is valid
+ * @param validBefore latest timestamp (unix seconds) when authorization expires
+ * @param nonce       random 32-byte nonce (NOT sequential)
+ * @see <a href="https://eips.ethereum.org/EIPS/eip-3009">EIP-3009</a>
+ */
+public record ReceiveAuthorization(
+    Address from,
+    Address to,
+    BigInteger value,
+    BigInteger validAfter,
+    BigInteger validBefore,
+    byte[] nonce
+) {
+    /** Length in bytes of the EIP-3009 nonce (bytes32). */
+    private static final int NONCE_LENGTH = 32;
+
+    /**
+     * EIP-712 typehash for ReceiveWithAuthorization.
+     *
+     * <p>{@code keccak256("ReceiveWithAuthorization(address from,address to,
+     * uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")}
+     */
+    public static final Hash TYPEHASH = new Hash(
+        "0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8");
+
+    /** EIP-712 type definition for ReceiveWithAuthorization. */
+    public static final TypeDefinition<ReceiveAuthorization> DEFINITION =
+        TypeDefinition.forRecord(
+            ReceiveAuthorization.class,
+            "ReceiveWithAuthorization",
+            Map.of("ReceiveWithAuthorization", List.of(
+                TypedDataField.of("from", "address"),
+                TypedDataField.of("to", "address"),
+                TypedDataField.of("value", "uint256"),
+                TypedDataField.of("validAfter", "uint256"),
+                TypedDataField.of("validBefore", "uint256"),
+                TypedDataField.of("nonce", "bytes32")
+            ))
+        );
+
+    /** Compact constructor — validates all fields and makes defensive copy of nonce. */
+    public ReceiveAuthorization {
+        Objects.requireNonNull(from, "from");
+        Objects.requireNonNull(to, "to");
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(validAfter, "validAfter");
+        Objects.requireNonNull(validBefore, "validBefore");
+        Objects.requireNonNull(nonce, "nonce");
+        if (validBefore.compareTo(validAfter) <= 0) {
+            throw new IllegalArgumentException(
+                "validBefore (" + validBefore + ") must be greater than validAfter (" + validAfter + ")");
+        }
+        if (nonce.length != NONCE_LENGTH) {
+            throw new IllegalArgumentException(
+                "nonce must be " + NONCE_LENGTH + " bytes, got " + nonce.length);
+        }
+        nonce = Arrays.copyOf(nonce, NONCE_LENGTH);
+    }
+
+    /**
+     * Returns the nonce bytes.
+     * <p>A defensive copy is returned to preserve immutability.
+     *
+     * @return a copy of the nonce bytes (32 bytes)
+     */
+    @Override
+    public byte[] nonce() {
+        return Arrays.copyOf(nonce, nonce.length);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof ReceiveAuthorization other)) return false;
+        return from.equals(other.from) && to.equals(other.to)
+            && value.equals(other.value)
+            && validAfter.equals(other.validAfter) && validBefore.equals(other.validBefore)
+            && Arrays.equals(nonce, other.nonce);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from, to, value, validAfter, validBefore, Arrays.hashCode(nonce));
+    }
+
+    @Override
+    public String toString() {
+        return "ReceiveAuthorization[from=" + from.value() + ", to=" + to.value()
+            + ", value=" + value + ", validAfter=" + validAfter
+            + ", validBefore=" + validBefore
+            + ", nonce=0x" + Hex.encodeNoPrefix(nonce) + "]";
+    }
+}

--- a/brane-core/src/main/java/sh/brane/core/crypto/eip3009/TransferAuthorization.java
+++ b/brane-core/src/main/java/sh/brane/core/crypto/eip3009/TransferAuthorization.java
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.core.crypto.eip3009;
+
+import sh.brane.core.crypto.eip712.TypeDefinition;
+import sh.brane.core.crypto.eip712.TypedDataField;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.Hash;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import sh.brane.primitives.Hex;
+
+/**
+ * EIP-3009 TransferWithAuthorization message.
+ *
+ * <p>Represents a signed authorization to transfer ERC-20 tokens from one address
+ * to another. The authorization is signed off-chain via EIP-712 and submitted
+ * on-chain by a relayer (the payer does not need to pay gas).
+ *
+ * @param from        the payer address
+ * @param to          the payee address
+ * @param value       the transfer amount in token smallest units
+ * @param validAfter  earliest timestamp (unix seconds) when authorization is valid
+ * @param validBefore latest timestamp (unix seconds) when authorization expires
+ * @param nonce       random 32-byte nonce (NOT sequential)
+ * @see <a href="https://eips.ethereum.org/EIPS/eip-3009">EIP-3009</a>
+ */
+public record TransferAuthorization(
+    Address from,
+    Address to,
+    BigInteger value,
+    BigInteger validAfter,
+    BigInteger validBefore,
+    byte[] nonce
+) {
+    /** Length in bytes of the EIP-3009 nonce (bytes32). */
+    private static final int NONCE_LENGTH = 32;
+
+    /**
+     * EIP-712 typehash for TransferWithAuthorization.
+     *
+     * <p>{@code keccak256("TransferWithAuthorization(address from,address to,
+     * uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")}
+     */
+    public static final Hash TYPEHASH = new Hash(
+        "0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267");
+
+    /** EIP-712 type definition for TransferWithAuthorization. */
+    public static final TypeDefinition<TransferAuthorization> DEFINITION =
+        TypeDefinition.forRecord(
+            TransferAuthorization.class,
+            "TransferWithAuthorization",
+            Map.of("TransferWithAuthorization", List.of(
+                TypedDataField.of("from", "address"),
+                TypedDataField.of("to", "address"),
+                TypedDataField.of("value", "uint256"),
+                TypedDataField.of("validAfter", "uint256"),
+                TypedDataField.of("validBefore", "uint256"),
+                TypedDataField.of("nonce", "bytes32")
+            ))
+        );
+
+    /** Compact constructor — validates all fields and makes defensive copy of nonce. */
+    public TransferAuthorization {
+        Objects.requireNonNull(from, "from");
+        Objects.requireNonNull(to, "to");
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(validAfter, "validAfter");
+        Objects.requireNonNull(validBefore, "validBefore");
+        Objects.requireNonNull(nonce, "nonce");
+        if (validBefore.compareTo(validAfter) <= 0) {
+            throw new IllegalArgumentException(
+                "validBefore (" + validBefore + ") must be greater than validAfter (" + validAfter + ")");
+        }
+        if (nonce.length != NONCE_LENGTH) {
+            throw new IllegalArgumentException(
+                "nonce must be " + NONCE_LENGTH + " bytes, got " + nonce.length);
+        }
+        nonce = Arrays.copyOf(nonce, NONCE_LENGTH);
+    }
+
+    /**
+     * Returns the nonce bytes.
+     * <p>A defensive copy is returned to preserve immutability.
+     *
+     * @return a copy of the nonce bytes (32 bytes)
+     */
+    @Override
+    public byte[] nonce() {
+        return Arrays.copyOf(nonce, nonce.length);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof TransferAuthorization other)) return false;
+        return from.equals(other.from) && to.equals(other.to)
+            && value.equals(other.value)
+            && validAfter.equals(other.validAfter) && validBefore.equals(other.validBefore)
+            && Arrays.equals(nonce, other.nonce);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from, to, value, validAfter, validBefore, Arrays.hashCode(nonce));
+    }
+
+    @Override
+    public String toString() {
+        return "TransferAuthorization[from=" + from.value() + ", to=" + to.value()
+            + ", value=" + value + ", validAfter=" + validAfter
+            + ", validBefore=" + validBefore
+            + ", nonce=0x" + Hex.encodeNoPrefix(nonce) + "]";
+    }
+}

--- a/brane-core/src/main/java/sh/brane/core/crypto/eip712/TypedDataEncoder.java
+++ b/brane-core/src/main/java/sh/brane/core/crypto/eip712/TypedDataEncoder.java
@@ -175,7 +175,8 @@ final class TypedDataEncoder {
             Map<String, List<TypedDataField>> types,
             Map<String, Object> data) {
         var fields = types.get(typeName);
-        // Each field encodes to exactly 32 bytes
+        // EIP-712: every field encodes to exactly 32 bytes
+        // (dynamic types like string/bytes are keccak256-hashed, structs are hashStruct'd)
         var encoded = new byte[fields.size() * 32];
         int offset = 0;
 

--- a/brane-core/src/test/java/sh/brane/core/crypto/eip3009/Eip3009Test.java
+++ b/brane-core/src/test/java/sh/brane/core/crypto/eip3009/Eip3009Test.java
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.core.crypto.eip3009;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import sh.brane.core.crypto.Keccak256;
+import sh.brane.core.crypto.PrivateKey;
+import sh.brane.core.crypto.PrivateKeySigner;
+import sh.brane.core.crypto.Signature;
+import sh.brane.core.crypto.eip712.Eip712Domain;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.Hash;
+
+class Eip3009Test {
+
+    // Anvil's first default key
+    private static final String TEST_PRIVATE_KEY =
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    private static final Address TEST_ADDRESS =
+        new Address("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+
+    private static final Address USDC_ADDRESS =
+        new Address("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+
+    private static final Address RECIPIENT =
+        new Address("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Typehash verification
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void transferAuthorization_typehashMatchesKeccak() {
+        byte[] computed = Keccak256.hash(
+            "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+                .getBytes());
+        assertEquals(TransferAuthorization.TYPEHASH, Hash.fromBytes(computed));
+    }
+
+    @Test
+    void receiveAuthorization_typehashMatchesKeccak() {
+        byte[] computed = Keccak256.hash(
+            "ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+                .getBytes());
+        assertEquals(ReceiveAuthorization.TYPEHASH, Hash.fromBytes(computed));
+    }
+
+    @Test
+    void cancelAuthorization_typehashMatchesKeccak() {
+        byte[] computed = Keccak256.hash(
+            "CancelAuthorization(address authorizer,bytes32 nonce)"
+                .getBytes());
+        assertEquals(CancelAuthorization.TYPEHASH, Hash.fromBytes(computed));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Domain helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void usdcDomain_hasCorrectFields() {
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        assertEquals("USD Coin", domain.name());
+        assertEquals("2", domain.version());
+        assertEquals(1L, domain.chainId());
+        assertEquals(USDC_ADDRESS, domain.verifyingContract());
+    }
+
+    @Test
+    void eurcDomain_hasCorrectFields() {
+        var addr = new Address("0x1234567890123456789012345678901234567890");
+        var domain = Eip3009.eurcDomain(8453L, addr);
+        assertEquals("EURC", domain.name());
+        assertEquals("2", domain.version());
+        assertEquals(8453L, domain.chainId());
+        assertEquals(addr, domain.verifyingContract());
+    }
+
+    @Test
+    void tokenDomain_hasCorrectFields() {
+        var addr = new Address("0x1234567890123456789012345678901234567890");
+        var domain = Eip3009.tokenDomain("MyToken", "1", 137L, addr);
+        assertEquals("MyToken", domain.name());
+        assertEquals("1", domain.version());
+        assertEquals(137L, domain.chainId());
+        assertEquals(addr, domain.verifyingContract());
+    }
+
+    @Test
+    void usdcDomain_rejectsNullAddress() {
+        assertThrows(NullPointerException.class,
+            () -> Eip3009.usdcDomain(1L, null));
+    }
+
+    @Test
+    void eurcDomain_rejectsNullAddress() {
+        assertThrows(NullPointerException.class,
+            () -> Eip3009.eurcDomain(1L, null));
+    }
+
+    @Test
+    void tokenDomain_rejectsNullName() {
+        var addr = new Address("0x1234567890123456789012345678901234567890");
+        assertThrows(NullPointerException.class,
+            () -> Eip3009.tokenDomain(null, "1", 1L, addr));
+    }
+
+    @Test
+    void tokenDomain_rejectsNullVersion() {
+        var addr = new Address("0x1234567890123456789012345678901234567890");
+        assertThrows(NullPointerException.class,
+            () -> Eip3009.tokenDomain("MyToken", null, 1L, addr));
+    }
+
+    @Test
+    void tokenDomain_rejectsNullAddress() {
+        assertThrows(NullPointerException.class,
+            () -> Eip3009.tokenDomain("MyToken", "1", 1L, null));
+    }
+
+    @Test
+    void usdcDomain_separator_isDeterministic() {
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        Hash sep1 = domain.separator();
+        Hash sep2 = domain.separator();
+        assertEquals(sep1, sep2);
+        assertNotNull(sep1);
+    }
+
+    @Test
+    void differentChains_produceDifferentSeparators() {
+        var domain1 = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        var domain8453 = Eip3009.usdcDomain(8453L, USDC_ADDRESS);
+        assertNotEquals(domain1.separator(), domain8453.separator());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Nonce generation
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void randomNonce_returns32Bytes() {
+        byte[] nonce = Eip3009.randomNonce();
+        assertEquals(32, nonce.length);
+    }
+
+    @Test
+    void randomNonce_producesUniqueValues() {
+        byte[] nonce1 = Eip3009.randomNonce();
+        byte[] nonce2 = Eip3009.randomNonce();
+        assertFalse(java.util.Arrays.equals(nonce1, nonce2));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Explicit factory
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void explicitFactory_createsDeterministicAuth() {
+        var nonce = new byte[32];
+        nonce[0] = 0x42;
+
+        var auth = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        assertEquals(TEST_ADDRESS, auth.from());
+        assertEquals(RECIPIENT, auth.to());
+        assertEquals(BigInteger.valueOf(1_000_000), auth.value());
+        assertEquals(BigInteger.ZERO, auth.validAfter());
+        assertEquals(BigInteger.valueOf(1_800_000_000L), auth.validBefore());
+        assertEquals((byte) 0x42, auth.nonce()[0]);
+    }
+
+    @Test
+    void explicitFactory_deterministicHash() {
+        var nonce = new byte[32];
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+
+        var auth1 = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+        var auth2 = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        assertEquals(Eip3009.hash(auth1, domain), Eip3009.hash(auth2, domain));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Convenience factory
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void convenienceFactory_setsValidTimestamps() {
+        var auth = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000), 3600);
+
+        // validAfter should be approximately now - 5
+        // validBefore should be approximately now + 3600
+        assertTrue(auth.validAfter().compareTo(auth.validBefore()) < 0);
+        assertEquals(32, auth.nonce().length);
+    }
+
+    @Test
+    void convenienceFactory_generatesRandomNonce() {
+        var auth1 = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000), 3600);
+        var auth2 = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000), 3600);
+
+        assertFalse(java.util.Arrays.equals(auth1.nonce(), auth2.nonce()));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Signing + hashing (TransferAuthorization)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void signTransfer_producesValidSignature() {
+        var signer = new PrivateKeySigner(TEST_PRIVATE_KEY);
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        var nonce = new byte[32];
+
+        var auth = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        Signature sig = Eip3009.sign(auth, domain, signer);
+        assertNotNull(sig);
+        assertEquals(32, sig.r().length);
+        assertEquals(32, sig.s().length);
+        assertTrue(sig.v() == 27 || sig.v() == 28);
+    }
+
+    @Test
+    void signTransfer_roundTrip_recoversAddress() {
+        var signer = new PrivateKeySigner(TEST_PRIVATE_KEY);
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        var nonce = new byte[32];
+
+        var auth = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        Hash hash = Eip3009.hash(auth, domain);
+        Signature sig = Eip3009.sign(auth, domain, signer);
+
+        Address recovered = PrivateKey.recoverAddress(hash.toBytes(), sig);
+        assertEquals(TEST_ADDRESS, recovered);
+    }
+
+    @Test
+    void hashTransfer_isDeterministic() {
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        var nonce = new byte[32];
+
+        var auth = Eip3009.transferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        Hash hash1 = Eip3009.hash(auth, domain);
+        Hash hash2 = Eip3009.hash(auth, domain);
+        assertEquals(hash1, hash2);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Signing + hashing (ReceiveAuthorization)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void signReceive_roundTrip_recoversAddress() {
+        var signer = new PrivateKeySigner(TEST_PRIVATE_KEY);
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        var nonce = new byte[32];
+
+        var auth = new ReceiveAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        Hash hash = Eip3009.hash(auth, domain);
+        Signature sig = Eip3009.sign(auth, domain, signer);
+
+        Address recovered = PrivateKey.recoverAddress(hash.toBytes(), sig);
+        assertEquals(TEST_ADDRESS, recovered);
+    }
+
+    @Test
+    void transferAndReceive_produceDifferentHashes() {
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        var nonce = new byte[32];
+
+        var transfer = new TransferAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+        var receive = new ReceiveAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        assertNotEquals(Eip3009.hash(transfer, domain), Eip3009.hash(receive, domain));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Signing + hashing (CancelAuthorization)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void signCancel_roundTrip_recoversAddress() {
+        var signer = new PrivateKeySigner(TEST_PRIVATE_KEY);
+        var domain = Eip3009.usdcDomain(1L, USDC_ADDRESS);
+        var nonce = new byte[32];
+
+        var cancel = new CancelAuthorization(TEST_ADDRESS, nonce);
+
+        Hash hash = Eip3009.hash(cancel, domain);
+        Signature sig = Eip3009.sign(cancel, domain, signer);
+
+        Address recovered = PrivateKey.recoverAddress(hash.toBytes(), sig);
+        assertEquals(TEST_ADDRESS, recovered);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Record validation (ReceiveAuthorization, CancelAuthorization)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void receiveAuthorization_rejectsNullFrom() {
+        assertThrows(NullPointerException.class,
+            () -> new ReceiveAuthorization(null, RECIPIENT, BigInteger.ONE,
+                BigInteger.ZERO, BigInteger.ONE, new byte[32]));
+    }
+
+    @Test
+    void receiveAuthorization_rejectsBadNonce() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ReceiveAuthorization(TEST_ADDRESS, RECIPIENT, BigInteger.ONE,
+                BigInteger.ZERO, BigInteger.ONE, new byte[16]));
+    }
+
+    @Test
+    void cancelAuthorization_rejectsNullAuthorizer() {
+        assertThrows(NullPointerException.class,
+            () -> new CancelAuthorization(null, new byte[32]));
+    }
+
+    @Test
+    void cancelAuthorization_rejectsBadNonce() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new CancelAuthorization(TEST_ADDRESS, new byte[10]));
+    }
+
+    @Test
+    void receiveAuthorization_definition_hasCorrectPrimaryType() {
+        assertEquals("ReceiveWithAuthorization", ReceiveAuthorization.DEFINITION.primaryType());
+    }
+
+    @Test
+    void cancelAuthorization_definition_hasCorrectPrimaryType() {
+        assertEquals("CancelAuthorization", CancelAuthorization.DEFINITION.primaryType());
+    }
+
+    @Test
+    void cancelAuthorization_definition_hasTwoFields() {
+        var fields = CancelAuthorization.DEFINITION.types().get("CancelAuthorization");
+        assertNotNull(fields);
+        assertEquals(2, fields.size());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Receive/Cancel factory methods
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void receiveAuthorizationFactory_explicit() {
+        var nonce = new byte[32];
+        nonce[0] = 0x42;
+        var auth = Eip3009.receiveAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000),
+            BigInteger.ZERO, BigInteger.valueOf(1_800_000_000L), nonce);
+
+        assertEquals(TEST_ADDRESS, auth.from());
+        assertEquals(RECIPIENT, auth.to());
+        assertEquals(BigInteger.valueOf(1_000_000), auth.value());
+        assertEquals((byte) 0x42, auth.nonce()[0]);
+    }
+
+    @Test
+    void receiveAuthorizationFactory_convenience() {
+        var auth = Eip3009.receiveAuthorization(
+            TEST_ADDRESS, RECIPIENT, BigInteger.valueOf(1_000_000), 3600);
+
+        assertTrue(auth.validAfter().compareTo(auth.validBefore()) < 0);
+        assertEquals(32, auth.nonce().length);
+    }
+
+    @Test
+    void cancelAuthorizationFactory_explicit() {
+        var nonce = new byte[32];
+        nonce[0] = 0x42;
+        var cancel = Eip3009.cancelAuthorization(TEST_ADDRESS, nonce);
+
+        assertEquals(TEST_ADDRESS, cancel.authorizer());
+        assertEquals((byte) 0x42, cancel.nonce()[0]);
+    }
+
+    @Test
+    void cancelAuthorizationFactory_randomNonce() {
+        var cancel1 = Eip3009.cancelAuthorization(TEST_ADDRESS);
+        var cancel2 = Eip3009.cancelAuthorization(TEST_ADDRESS);
+
+        assertEquals(32, cancel1.nonce().length);
+        assertFalse(java.util.Arrays.equals(cancel1.nonce(), cancel2.nonce()));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Validity window validation
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void receiveAuthorization_rejectsInvertedWindow() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ReceiveAuthorization(TEST_ADDRESS, RECIPIENT, BigInteger.ONE,
+                BigInteger.valueOf(1000), BigInteger.valueOf(500), new byte[32]));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // toString
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    void receiveAuthorization_toString_includesHexNonce() {
+        var nonce = new byte[32];
+        nonce[0] = (byte) 0xAB;
+        var auth = new ReceiveAuthorization(TEST_ADDRESS, RECIPIENT, BigInteger.ONE,
+            BigInteger.ZERO, BigInteger.ONE, nonce);
+        String str = auth.toString();
+        assertTrue(str.contains("nonce=0xab"), "toString should contain hex nonce, got: " + str);
+        assertFalse(str.contains("[B@"), "toString should not contain array reference, got: " + str);
+    }
+
+    @Test
+    void cancelAuthorization_toString_includesHexNonce() {
+        var nonce = new byte[32];
+        nonce[0] = (byte) 0xCD;
+        var cancel = new CancelAuthorization(TEST_ADDRESS, nonce);
+        String str = cancel.toString();
+        assertTrue(str.contains("nonce=0xcd"), "toString should contain hex nonce, got: " + str);
+        assertFalse(str.contains("[B@"), "toString should not contain array reference, got: " + str);
+    }
+}

--- a/brane-core/src/test/java/sh/brane/core/crypto/eip3009/TransferAuthorizationTest.java
+++ b/brane-core/src/test/java/sh/brane/core/crypto/eip3009/TransferAuthorizationTest.java
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.core.crypto.eip3009;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import sh.brane.core.types.Address;
+
+class TransferAuthorizationTest {
+
+    private static final Address FROM =
+        new Address("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    private static final Address TO =
+        new Address("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    private static final BigInteger VALUE = BigInteger.valueOf(1_000_000);
+    private static final BigInteger VALID_AFTER = BigInteger.ZERO;
+    private static final BigInteger VALID_BEFORE = BigInteger.valueOf(1_800_000_000L);
+    private static final byte[] NONCE = new byte[32]; // all zeros
+
+    @Test
+    void constructor_validatesAllFields() {
+        var auth = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, NONCE);
+        assertEquals(FROM, auth.from());
+        assertEquals(TO, auth.to());
+        assertEquals(VALUE, auth.value());
+        assertEquals(VALID_AFTER, auth.validAfter());
+        assertEquals(VALID_BEFORE, auth.validBefore());
+        assertArrayEquals(NONCE, auth.nonce());
+    }
+
+    @Test
+    void constructor_rejectsNullFrom() {
+        assertThrows(NullPointerException.class,
+            () -> new TransferAuthorization(null, TO, VALUE, VALID_AFTER, VALID_BEFORE, NONCE));
+    }
+
+    @Test
+    void constructor_rejectsNullTo() {
+        assertThrows(NullPointerException.class,
+            () -> new TransferAuthorization(FROM, null, VALUE, VALID_AFTER, VALID_BEFORE, NONCE));
+    }
+
+    @Test
+    void constructor_rejectsNullValue() {
+        assertThrows(NullPointerException.class,
+            () -> new TransferAuthorization(FROM, TO, null, VALID_AFTER, VALID_BEFORE, NONCE));
+    }
+
+    @Test
+    void constructor_rejectsNullValidAfter() {
+        assertThrows(NullPointerException.class,
+            () -> new TransferAuthorization(FROM, TO, VALUE, null, VALID_BEFORE, NONCE));
+    }
+
+    @Test
+    void constructor_rejectsNullValidBefore() {
+        assertThrows(NullPointerException.class,
+            () -> new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, null, NONCE));
+    }
+
+    @Test
+    void constructor_rejectsNullNonce() {
+        assertThrows(NullPointerException.class,
+            () -> new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, null));
+    }
+
+    @Test
+    void constructor_rejectsShortNonce() {
+        var shortNonce = new byte[31];
+        assertThrows(IllegalArgumentException.class,
+            () -> new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, shortNonce));
+    }
+
+    @Test
+    void constructor_rejectsLongNonce() {
+        var longNonce = new byte[33];
+        assertThrows(IllegalArgumentException.class,
+            () -> new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, longNonce));
+    }
+
+    @Test
+    void nonce_returnsDefensiveCopy() {
+        var original = new byte[32];
+        original[0] = 0x42;
+        var auth = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, original);
+
+        // Mutating original should not affect stored nonce
+        original[0] = 0x00;
+        assertEquals((byte) 0x42, auth.nonce()[0]);
+
+        // Mutating returned nonce should not affect stored nonce
+        byte[] returned = auth.nonce();
+        returned[0] = 0x00;
+        assertEquals((byte) 0x42, auth.nonce()[0]);
+    }
+
+    @Test
+    void equals_sameValues() {
+        var a = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, NONCE);
+        var b = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, NONCE);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void equals_differentNonce() {
+        var nonceA = new byte[32];
+        nonceA[0] = 1;
+        var nonceB = new byte[32];
+        nonceB[0] = 2;
+        var a = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, nonceA);
+        var b = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, nonceB);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void equals_reflexive() {
+        var auth = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, NONCE);
+        assertEquals(auth, auth);
+    }
+
+    @Test
+    void equals_notEqualToNull() {
+        var auth = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, NONCE);
+        assertNotEquals(null, auth);
+    }
+
+    @Test
+    void constructor_rejectsInvertedWindow() {
+        // validBefore (500) <= validAfter (1000)
+        assertThrows(IllegalArgumentException.class,
+            () -> new TransferAuthorization(FROM, TO, VALUE,
+                BigInteger.valueOf(1000), BigInteger.valueOf(500), NONCE));
+    }
+
+    @Test
+    void constructor_rejectsEqualWindow() {
+        // validBefore == validAfter
+        var same = BigInteger.valueOf(1000);
+        assertThrows(IllegalArgumentException.class,
+            () -> new TransferAuthorization(FROM, TO, VALUE, same, same, NONCE));
+    }
+
+    @Test
+    void toString_includesHexNonce() {
+        var nonce = new byte[32];
+        nonce[0] = 0x42;
+        var auth = new TransferAuthorization(FROM, TO, VALUE, VALID_AFTER, VALID_BEFORE, nonce);
+        String str = auth.toString();
+        assertTrue(str.contains("nonce=0x42"), "toString should contain hex nonce, got: " + str);
+        assertFalse(str.contains("[B@"), "toString should not contain array reference, got: " + str);
+    }
+
+    @Test
+    void definition_hasCorrectPrimaryType() {
+        assertEquals("TransferWithAuthorization", TransferAuthorization.DEFINITION.primaryType());
+    }
+
+    @Test
+    void definition_hasCorrectFieldCount() {
+        var fields = TransferAuthorization.DEFINITION.types().get("TransferWithAuthorization");
+        assertNotNull(fields);
+        assertEquals(6, fields.size());
+    }
+}

--- a/brane-examples/CLAUDE.md
+++ b/brane-examples/CLAUDE.md
@@ -39,6 +39,7 @@ anvil --hardfork cancun
 | `TxBuilderExample` | Transaction builder patterns |
 | `Erc20TransferLogExample` | Event log decoding |
 | `MultiChainLatestBlockExample` | Multi-chain support |
+| `Eip3009Example` | EIP-3009 gasless transfer authorization signing (USDC) |
 
 ## Sanity Checks
 

--- a/brane-examples/src/main/java/sh/brane/examples/Eip3009Example.java
+++ b/brane-examples/src/main/java/sh/brane/examples/Eip3009Example.java
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.examples;
+
+import java.math.BigInteger;
+
+import sh.brane.core.AnsiColors;
+import sh.brane.core.crypto.PrivateKeySigner;
+import sh.brane.core.crypto.Signature;
+import sh.brane.core.crypto.eip3009.Eip3009;
+import sh.brane.core.crypto.eip3009.TransferAuthorization;
+import sh.brane.core.crypto.eip712.Eip712Domain;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.Hash;
+import sh.brane.primitives.Hex;
+
+/**
+ * Demonstrates EIP-3009 TransferWithAuthorization signing using Brane.
+ *
+ * <p>EIP-3009 enables meta-transactions — gasless token transfers via signed
+ * EIP-712 authorizations. Instead of the token holder submitting an on-chain
+ * transaction, they sign an authorization off-chain, and a relayer submits it.
+ *
+ * <p>This is the on-chain primitive powering <a href="https://www.x402.org/">x402</a> —
+ * Coinbase's HTTP-native payment protocol for USDC.
+ *
+ * <p>This example demonstrates:
+ * <ol>
+ *   <li>Creating the EIP-712 domain for USDC</li>
+ *   <li>Building a TransferWithAuthorization message</li>
+ *   <li>Signing with EIP-712 and extracting v, r, s components</li>
+ *   <li>Showing the parameters needed for on-chain submission</li>
+ * </ol>
+ *
+ * <p>Usage:
+ * <pre>
+ * ./gradlew :brane-examples:run --no-daemon \
+ *     -PmainClass=sh.brane.examples.Eip3009Example
+ * </pre>
+ *
+ * @see <a href="https://eips.ethereum.org/EIPS/eip-3009">EIP-3009</a>
+ */
+public final class Eip3009Example {
+
+    // Test private key (Anvil's default account #0)
+    private static final String PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    private Eip3009Example() {
+        // Prevent instantiation
+    }
+
+    public static void main(String[] args) {
+        System.out.println("=== EIP-3009 Transfer With Authorization Example ===\n");
+
+        // Create signer from private key
+        var signer = new PrivateKeySigner(PRIVATE_KEY);
+        Address from = signer.address();
+        System.out.println("Signer address: " + from.value());
+
+        // =====================================================================
+        // Step 1: Create EIP-712 Domain for USDC
+        // =====================================================================
+        System.out.println("\n[1] Creating EIP-712 Domain for USDC");
+
+        // USDC on Ethereum mainnet
+        Address usdcAddress = new Address("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        Eip712Domain domain = Eip3009.usdcDomain(1L, usdcAddress);
+
+        System.out.println("  Token: " + domain.name());
+        System.out.println("  Version: " + domain.version());
+        System.out.println("  Chain: " + domain.chainId());
+        System.out.println("  Contract: " + domain.verifyingContract().value());
+        System.out.println("  Domain separator: " + domain.separator().value());
+
+        // =====================================================================
+        // Step 2: Create TransferWithAuthorization Message
+        // =====================================================================
+        System.out.println("\n[2] Creating TransferWithAuthorization");
+
+        Address recipient = new Address("0x70997970c51812dc3a010c7d01b50e0d17dc79c8");
+        BigInteger value = BigInteger.valueOf(1_000_000); // 1 USDC (6 decimals)
+
+        // Explicit factory for deterministic example output
+        byte[] nonce = Eip3009.randomNonce();
+        TransferAuthorization auth = Eip3009.transferAuthorization(
+            from, recipient, value,
+            BigInteger.ZERO,                      // validAfter: immediately
+            BigInteger.valueOf(2_000_000_000L),   // validBefore: far future
+            nonce
+        );
+
+        System.out.println("  From: " + auth.from().value());
+        System.out.println("  To: " + auth.to().value());
+        System.out.println("  Value: " + auth.value() + " (1 USDC)");
+        System.out.println("  Valid after: " + auth.validAfter());
+        System.out.println("  Valid before: " + auth.validBefore());
+        System.out.println("  Nonce: 0x" + Hex.encodeNoPrefix(auth.nonce()));
+
+        // =====================================================================
+        // Step 3: Compute Hash and Sign
+        // =====================================================================
+        System.out.println("\n[3] Signing Authorization");
+
+        Hash hash = Eip3009.hash(auth, domain);
+        System.out.println("  EIP-712 hash: " + hash.value());
+
+        Signature sig = Eip3009.sign(auth, domain, signer);
+        System.out.println(AnsiColors.success("  Signature: " + sig));
+
+        // =====================================================================
+        // Step 4: Extract v, r, s for On-Chain Submission
+        // =====================================================================
+        System.out.println("\n[4] Extracting Signature Components");
+
+        byte[] r = sig.r();
+        byte[] s = sig.s();
+        int v = sig.v();
+
+        System.out.println("  v: " + v);
+        System.out.println("  r: 0x" + Hex.encodeNoPrefix(r));
+        System.out.println("  s: 0x" + Hex.encodeNoPrefix(s));
+
+        // =====================================================================
+        // Step 5: Show Contract Call Parameters
+        // =====================================================================
+        System.out.println("\n[5] Contract Call Parameters");
+        System.out.println("  To call transferWithAuthorization(from, to, value, validAfter, validBefore, nonce, v, r, s):");
+        System.out.println("    from:        " + auth.from().value());
+        System.out.println("    to:          " + auth.to().value());
+        System.out.println("    value:       " + auth.value());
+        System.out.println("    validAfter:  " + auth.validAfter());
+        System.out.println("    validBefore: " + auth.validBefore());
+        System.out.println("    nonce:       0x" + Hex.encodeNoPrefix(auth.nonce()));
+        System.out.println("    v:           " + v);
+        System.out.println("    r:           0x" + Hex.encodeNoPrefix(r));
+        System.out.println("    s:           0x" + Hex.encodeNoPrefix(s));
+
+        // =====================================================================
+        // Step 6: Demonstrate Convenience Factory
+        // =====================================================================
+        System.out.println("\n[6] Convenience Factory (auto nonce + time window)");
+
+        TransferAuthorization autoAuth = Eip3009.transferAuthorization(
+            from, recipient, value, 3600  // valid for 1 hour
+        );
+
+        System.out.println("  Valid after: " + autoAuth.validAfter() + " (now - 5s)");
+        System.out.println("  Valid before: " + autoAuth.validBefore() + " (now + 1h)");
+        System.out.println("  Nonce: 0x" + Hex.encodeNoPrefix(autoAuth.nonce()) + " (random)");
+
+        System.out.println("\n" + AnsiColors.success("EIP-3009 Transfer With Authorization signing completed successfully!"));
+    }
+}

--- a/brane-rpc/src/test/java/sh/brane/rpc/Eip3009IntegrationTest.java
+++ b/brane-rpc/src/test/java/sh/brane/rpc/Eip3009IntegrationTest.java
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package sh.brane.rpc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import sh.brane.core.abi.Abi;
+import sh.brane.core.builder.TxBuilder;
+import sh.brane.core.crypto.PrivateKeySigner;
+import sh.brane.core.crypto.Signature;
+import sh.brane.core.crypto.eip3009.Eip3009;
+import sh.brane.core.crypto.eip712.Eip712Domain;
+import sh.brane.core.error.RevertException;
+import sh.brane.core.model.TransactionReceipt;
+import sh.brane.core.model.TransactionRequest;
+import sh.brane.core.types.Address;
+import sh.brane.core.types.HexData;
+import sh.brane.core.types.Wei;
+import sh.brane.rpc.test.BraneTestExtension;
+
+/**
+ * Integration tests for EIP-3009 authorization signing against a live Anvil node.
+ *
+ * <p>Deploys a mock EIP-3009 token contract, signs authorizations using the
+ * Brane EIP-3009 library, and submits them on-chain to verify correctness.
+ *
+ * <p>Requires Anvil running on localhost:8545.
+ *
+ * @see <a href="https://eips.ethereum.org/EIPS/eip-3009">EIP-3009</a>
+ */
+@ExtendWith(BraneTestExtension.class)
+@EnabledIfSystemProperty(named = "brane.integration.tests", matches = "true")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("EIP-3009 Integration Tests")
+class Eip3009IntegrationTest {
+
+    // Anvil's default funded account
+    private static final String PRIVATE_KEY =
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    // Second Anvil account (for receiving)
+    private static final String RECIPIENT_KEY =
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+
+    private static final String TOKEN_NAME = "USD Coin";
+    private static final String TOKEN_VERSION = "2";
+    private static final BigInteger INITIAL_SUPPLY = BigInteger.valueOf(1_000_000_000); // 1000 USDC (6 decimals)
+
+    // @formatter:off
+    private static final String MOCK_TOKEN_ABI = """
+        [
+          {"type":"constructor","inputs":[{"name":"_name","type":"string"},{"name":"_version","type":"string"},{"name":"initialSupply","type":"uint256"}],"stateMutability":"nonpayable"},
+          {"type":"function","name":"balanceOf","inputs":[{"name":"account","type":"address"}],"outputs":[{"name":"","type":"uint256"}],"stateMutability":"view"},
+          {"type":"function","name":"authorizationState","inputs":[{"name":"authorizer","type":"address"},{"name":"nonce","type":"bytes32"}],"outputs":[{"name":"","type":"bool"}],"stateMutability":"view"},
+          {"type":"function","name":"transferWithAuthorization","inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"},{"name":"validAfter","type":"uint256"},{"name":"validBefore","type":"uint256"},{"name":"nonce","type":"bytes32"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],"outputs":[],"stateMutability":"nonpayable"},
+          {"type":"function","name":"receiveWithAuthorization","inputs":[{"name":"from","type":"address"},{"name":"to","type":"address"},{"name":"value","type":"uint256"},{"name":"validAfter","type":"uint256"},{"name":"validBefore","type":"uint256"},{"name":"nonce","type":"bytes32"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],"outputs":[],"stateMutability":"nonpayable"},
+          {"type":"function","name":"cancelAuthorization","inputs":[{"name":"authorizer","type":"address"},{"name":"nonce","type":"bytes32"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],"outputs":[],"stateMutability":"nonpayable"}
+        ]
+        """;
+
+    private static final String MOCK_TOKEN_BYTECODE =
+        "0x608060405234801561000f575f5ffd5b50604051611f36380380611f36833981810160405281019061003191906102e2565b825f908161003f9190610582565b50816001908161004f9190610582565b508060025f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20819055503373ffffffffffffffffffffffffffffffffffffffff165f73ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040516100ef9190610660565b60405180910390a37f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f83805190602001208380519060200120463060405160200161013e9594939291906106d0565b60405160208183030381529060405280519060200120600481905550505050610721565b5f604051905090565b5f5ffd5b5f5ffd5b5f5ffd5b5f5ffd5b5f601f19601f8301169050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b6101c18261017b565b810181811067ffffffffffffffff821117156101e0576101df61018b565b5b80604052505050565b5f6101f2610162565b90506101fe82826101b8565b919050565b5f67ffffffffffffffff82111561021d5761021c61018b565b5b6102268261017b565b9050602081019050919050565b8281835e5f83830152505050565b5f61025361024e84610203565b6101e9565b90508281526020810184848401111561026f5761026e610177565b5b61027a848285610233565b509392505050565b5f82601f83011261029657610295610173565b5b81516102a6848260208601610241565b91505092915050565b5f819050919050565b6102c1816102af565b81146102cb575f5ffd5b50565b5f815190506102dc816102b8565b92915050565b5f5f5f606084860312156102f9576102f861016b565b5b5f84015167ffffffffffffffff8111156103165761031561016f565b5b61032286828701610282565b935050602084015167ffffffffffffffff8111156103435761034261016f565b5b61034f86828701610282565b9250506040610360868287016102ce565b9150509250925092565b5f81519050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f60028204905060018216806103b857607f821691505b6020821081036103cb576103ca610374565b5b50919050565b5f819050815f5260205f209050919050565b5f6020601f8301049050919050565b5f82821b905092915050565b5f6008830261042d7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff826103f2565b61043786836103f2565b95508019841693508086168417925050509392505050565b5f819050919050565b5f61047261046d610468846102af565b61044f565b6102af565b9050919050565b5f819050919050565b61048b83610458565b61049f61049782610479565b8484546103fe565b825550505050565b5f5f905090565b6104b66104a7565b6104c1818484610482565b505050565b5f5b828110156104e7576104dc5f8284016104ae565b6001810190506104c8565b505050565b601f82111561053a578282111561053957610506816103d1565b61050f846103e3565b610518856103e3565b6020861015610525575f90505b808301610534828403826104c6565b505050505b5b505050565b5f82821c905092915050565b5f61055a5f198460080261053f565b1980831691505092915050565b5f610572838361054b565b9150826002028217905092915050565b61058b8261036a565b67ffffffffffffffff8111156105a4576105a361018b565b5b6105ae82546103a1565b6105b98282856104ec565b5f60209050601f8311600181146105ea575f84156105d8578287015190505b6105e28582610567565b865550610649565b601f1984166105f8866103d1565b5f5b8281101561061f578489015182556001820191506020850194506020810190506105fa565b8683101561063c5784890151610638601f89168261054b565b8355505b6001600288020188555050505b505050505050565b61065a816102af565b82525050565b5f6020820190506106735f830184610651565b92915050565b5f819050919050565b61068b81610679565b82525050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6106ba82610691565b9050919050565b6106ca816106b0565b82525050565b5f60a0820190506106e35f830188610682565b6106f06020830187610682565b6106fd6040830186610682565b61070a6060830185610651565b61071760808301846106c1565b9695505050505050565b6118088061072e5f395ff3fe608060405234801561000f575f5ffd5b5060043610610091575f3560e01c80635a049a70116100645780635a049a701461010d57806370a0823114610129578063e3ee160e14610159578063e94a010214610175578063ef55bec6146101a557610091565b806306fdde0314610095578063313ce567146100b35780633644e515146100d157806354fd4d50146100ef575b5f5ffd5b61009d6101c1565b6040516100aa9190610fd3565b60405180910390f35b6100bb61024c565b6040516100c8919061100e565b60405180910390f35b6100d9610251565b6040516100e6919061103f565b60405180910390f35b6100f7610257565b6040516101049190610fd3565b60405180910390f35b6101276004803603810190610122919061110a565b6102e3565b005b610143600480360381019061013e9190611181565b61059f565b60405161015091906111c4565b60405180910390f35b610173600480360381019061016e9190611207565b6105e5565b005b61018f600480360381019061018a91906112cb565b610a3c565b60405161019c9190611323565b60405180910390f35b6101bf60048036038101906101ba9190611207565b610a9e565b005b5f80546101cd90611369565b80601f01602080910402602001604051908101604052809291908181526020018280546101f990611369565b80156102445780601f1061021b57610100808354040283529160200191610244565b820191905f5260205f20905b81548152906001019060200180831161022757829003601f168201915b505050505081565b600681565b60045481565b6001805461026490611369565b80601f016020809104026020016040519081016040528092919081815260200182805461029090611369565b80156102db5780601f106102b2576101008083540402835291602001916102db565b820191905f5260205f20905b8154815290600101906020018083116102be57829003601f168201915b505050505081565b60035f8673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8581526020019081526020015f205f9054906101000a900460ff161561037c576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610373906113e3565b60405180910390fd5b5f7f158b0a9edf7a828aad02f63cd515c68ef2f50ba807396f6d12842833a159742986866040516020016103b293929190611410565b6040516020818303038152906040528051906020012090505f600454826040516020016103e09291906114b9565b6040516020818303038152906040528051906020012090505f6001828787876040515f815260200160405260405161041b94939291906114ef565b6020604051602081039080840390855afa15801561043b573d5f5f3e3d5ffd5b5050506020604051035190505f73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff16141580156104ae57508773ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff16145b6104ed576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016104e49061157c565b60405180910390fd5b600160035f8a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8981526020019081526020015f205f6101000a81548160ff021916908315150217905550868873ffffffffffffffffffffffffffffffffffffffff167f1cdd46ff242716cdaa72d159d339a485b3438398348d68f09d7c8c0a59353d8160405160405180910390a35050505050505050565b5f60025f8373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20549050919050565b854211610627576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040161061e906115e4565b60405180910390fd5b844210610669576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106609061164c565b60405180910390fd5b60035f8a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8581526020019081526020015f205f9054906101000a900460ff1615610702576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106f9906113e3565b60405180910390fd5b5f7f7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a22678a8a8a8a8a8a604051602001610740979695949392919061166a565b6040516020818303038152906040528051906020012090505f6004548260405160200161076e9291906114b9565b6040516020818303038152906040528051906020012090505f6001828787876040515f81526020016040526040516107a994939291906114ef565b6020604051602081039080840390855afa1580156107c9573d5f5f3e3d5ffd5b5050506020604051035190505f73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff161415801561083c57508b73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff16145b61087b576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016108729061157c565b60405180910390fd5b600160035f8e73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8981526020019081526020015f205f6101000a81548160ff0219169083151502179055508960025f8e73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825461092b9190611704565b925050819055508960025f8d73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825461097e9190611737565b925050819055508a73ffffffffffffffffffffffffffffffffffffffff168c73ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8c6040516109e291906111c4565b60405180910390a3868c73ffffffffffffffffffffffffffffffffffffffff167f98de503528ee59b575ef0c0a2576a82497bfc029a5685b209e9ec333479b10a560405160405180910390a3505050505050505050505050565b5f60035f8473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8381526020019081526020015f205f9054906101000a900460ff16905092915050565b3373ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614610b0c576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610b03906117b4565b60405180910390fd5b854211610b4e576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610b45906115e4565b60405180910390fd5b844210610b90576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610b879061164c565b60405180910390fd5b60035f8a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8581526020019081526020015f205f9054906101000a900460ff1615610c29576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610c20906113e3565b60405180910390fd5b5f7fd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de88a8a8a8a8a8a604051602001610c67979695949392919061166a565b6040516020818303038152906040528051906020012090505f60045482604051602001610c959291906114b9565b6040516020818303038152906040528051906020012090505f6001828787876040515f8152602001604052604051610cd094939291906114ef565b6020604051602081039080840390855afa158015610cf0573d5f5f3e3d5ffd5b5050506020604051035190505f73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614158015610d6357508b73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff16145b610da2576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610d999061157c565b60405180910390fd5b600160035f8e73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8981526020019081526020015f205f6101000a81548160ff0219169083151502179055508960025f8e73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f828254610e529190611704565b925050819055508960025f8d73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f828254610ea59190611737565b925050819055508a73ffffffffffffffffffffffffffffffffffffffff168c73ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8c604051610f0991906111c4565b60405180910390a3868c73ffffffffffffffffffffffffffffffffffffffff167f98de503528ee59b575ef0c0a2576a82497bfc029a5685b209e9ec333479b10a560405160405180910390a3505050505050505050505050565b5f81519050919050565b5f82825260208201905092915050565b8281835e5f83830152505050565b5f601f19601f8301169050919050565b5f610fa582610f63565b610faf8185610f6d565b9350610fbf818560208601610f7d565b610fc881610f8b565b840191505092915050565b5f6020820190508181035f830152610feb8184610f9b565b905092915050565b5f60ff82169050919050565b61100881610ff3565b82525050565b5f6020820190506110215f830184610fff565b92915050565b5f819050919050565b61103981611027565b82525050565b5f6020820190506110525f830184611030565b92915050565b5f5ffd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6110858261105c565b9050919050565b6110958161107b565b811461109f575f5ffd5b50565b5f813590506110b08161108c565b92915050565b6110bf81611027565b81146110c9575f5ffd5b50565b5f813590506110da816110b6565b92915050565b6110e981610ff3565b81146110f3575f5ffd5b50565b5f81359050611104816110e0565b92915050565b5f5f5f5f5f60a0868803121561112357611122611058565b5b5f611130888289016110a2565b9550506020611141888289016110cc565b9450506040611152888289016110f6565b9350506060611163888289016110cc565b9250506080611174888289016110cc565b9150509295509295909350565b5f6020828403121561119657611195611058565b5b5f6111a3848285016110a2565b91505092915050565b5f819050919050565b6111be816111ac565b82525050565b5f6020820190506111d75f8301846111b5565b92915050565b6111e6816111ac565b81146111f0575f5ffd5b50565b5f81359050611201816111dd565b92915050565b5f5f5f5f5f5f5f5f5f6101208a8c03121561122557611224611058565b5b5f6112328c828d016110a2565b99505060206112438c828d016110a2565b98505060406112548c828d016111f3565b97505060606112658c828d016111f3565b96505060806112768c828d016111f3565b95505060a06112878c828d016110cc565b94505060c06112988c828d016110f6565b93505060e06112a98c828d016110cc565b9250506101006112bb8c828d016110cc565b9150509295985092959850929598565b5f5f604083850312156112e1576112e0611058565b5b5f6112ee858286016110a2565b92505060206112ff858286016110cc565b9150509250929050565b5f8115159050919050565b61131d81611309565b82525050565b5f6020820190506113365f830184611314565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f600282049050600182168061138057607f821691505b6020821081036113935761139261133c565b5b50919050565b7f417574686f72697a6174696f6e20616c726561647920757365640000000000005f82015250565b5f6113cd601a83610f6d565b91506113d882611399565b602082019050919050565b5f6020820190508181035f8301526113fa816113c1565b9050919050565b61140a8161107b565b82525050565b5f6060820190506114235f830186611030565b6114306020830185611401565b61143d6040830184611030565b949350505050565b5f81905092915050565b7f19010000000000000000000000000000000000000000000000000000000000005f82015250565b5f611483600283611445565b915061148e8261144f565b600282019050919050565b5f819050919050565b6114b36114ae82611027565b611499565b82525050565b5f6114c382611477565b91506114cf82856114a2565b6020820191506114df82846114a2565b6020820191508190509392505050565b5f6080820190506115025f830187611030565b61150f6020830186610fff565b61151c6040830185611030565b6115296060830184611030565b95945050505050565b7f496e76616c6964207369676e61747572650000000000000000000000000000005f82015250565b5f611566601183610f6d565b915061157182611532565b602082019050919050565b5f6020820190508181035f8301526115938161155a565b9050919050565b7f417574686f72697a6174696f6e206e6f74207965742076616c696400000000005f82015250565b5f6115ce601b83610f6d565b91506115d98261159a565b602082019050919050565b5f6020820190508181035f8301526115fb816115c2565b9050919050565b7f417574686f72697a6174696f6e206578706972656400000000000000000000005f82015250565b5f611636601583610f6d565b915061164182611602565b602082019050919050565b5f6020820190508181035f8301526116638161162a565b9050919050565b5f60e08201905061167d5f83018a611030565b61168a6020830189611401565b6116976040830188611401565b6116a460608301876111b5565b6116b160808301866111b5565b6116be60a08301856111b5565b6116cb60c0830184611030565b98975050505050505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61170e826111ac565b9150611719836111ac565b9250828203905081811115611731576117306116d7565b5b92915050565b5f611741826111ac565b915061174c836111ac565b9250828201905080821115611764576117636116d7565b5b92915050565b7f43616c6c6572206d7573742062652074686520706179656500000000000000005f82015250565b5f61179e601883610f6d565b91506117a98261176a565b602082019050919050565b5f6020820190508181035f8301526117cb81611792565b905091905056fea2646970667358221220bb176b439f132955b64fe6e82a399597edd3038ae5000a536e23b227620e04c364736f6c63430008210033";
+    // @formatter:on
+
+    private PrivateKeySigner signer;
+    private PrivateKeySigner recipientSigner;
+    private Address tokenAddress;
+    private Eip712Domain domain;
+    private Abi abi;
+
+    @BeforeAll
+    void deployToken(Brane.Signer client) {
+        signer = new PrivateKeySigner(PRIVATE_KEY);
+        recipientSigner = new PrivateKeySigner(RECIPIENT_KEY);
+
+        abi = Abi.fromJson(MOCK_TOKEN_ABI);
+        HexData encodedArgs = abi.encodeConstructor(TOKEN_NAME, TOKEN_VERSION, INITIAL_SUPPLY);
+        String data = MOCK_TOKEN_BYTECODE + encodedArgs.value().substring(2);
+
+        TransactionRequest request = TxBuilder.eip1559()
+            .data(new HexData(data))
+            .value(Wei.ZERO)
+            .build();
+
+        TransactionReceipt receipt = client.sendTransactionAndWait(request, 30_000, 500);
+        assertTrue(receipt.status(), "Token deployment failed");
+        tokenAddress = receipt.contractAddress();
+
+        // Anvil uses chain ID 31337
+        domain = Eip3009.tokenDomain(TOKEN_NAME, TOKEN_VERSION, 31337L, tokenAddress);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Helper methods
+    // ═══════════════════════════════════════════════════════════════════
+
+    private BigInteger getBalance(Brane client, Address account) {
+        Abi.FunctionCall call = abi.encodeFunction("balanceOf", account);
+        HexData result = client.call(CallRequest.of(tokenAddress, new HexData(call.data())));
+        return call.decode(result.value(), BigInteger.class);
+    }
+
+    private boolean getAuthorizationState(Brane client, Address authorizer, byte[] nonce) {
+        Abi.FunctionCall call = abi.encodeFunction("authorizationState", authorizer, nonce);
+        HexData result = client.call(CallRequest.of(tokenAddress, new HexData(call.data())));
+        return call.decode(result.value(), Boolean.class);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // transferWithAuthorization
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(1)
+    @DisplayName("transferWithAuthorization: sign and submit on-chain, verify balance changed")
+    void transferWithAuthorization_works(Brane.Signer client) {
+        Address from = signer.address();
+        Address to = recipientSigner.address();
+        BigInteger value = BigInteger.valueOf(1_000_000); // 1 USDC
+
+        BigInteger fromBefore = getBalance(client, from);
+        BigInteger toBefore = getBalance(client, to);
+
+        byte[] nonce = Eip3009.randomNonce();
+        var auth = Eip3009.transferAuthorization(
+            from, to, value, BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce);
+        Signature sig = Eip3009.sign(auth, domain, signer);
+
+        // Submit via any account (relayer pattern)
+        Abi.FunctionCall call = abi.encodeFunction("transferWithAuthorization",
+            from, to, value,
+            BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce,
+            BigInteger.valueOf(sig.v()), sig.r(), sig.s());
+
+        TransactionRequest txRequest = TxBuilder.eip1559()
+            .to(tokenAddress)
+            .data(new HexData(call.data()))
+            .build();
+
+        TransactionReceipt receipt = client.sendTransactionAndWait(txRequest, 30_000, 500);
+        assertTrue(receipt.status(), "transferWithAuthorization failed");
+
+        BigInteger fromAfter = getBalance(client, from);
+        BigInteger toAfter = getBalance(client, to);
+        assertEquals(fromBefore.subtract(value), fromAfter);
+        assertEquals(toBefore.add(value), toAfter);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("authorizationState returns true after transferWithAuthorization")
+    void authorizationState_trueAfterTransfer(Brane.Signer client) {
+        Address from = signer.address();
+        Address to = recipientSigner.address();
+        BigInteger value = BigInteger.valueOf(100);
+
+        byte[] nonce = Eip3009.randomNonce();
+        var auth = Eip3009.transferAuthorization(
+            from, to, value, BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce);
+        Signature sig = Eip3009.sign(auth, domain, signer);
+
+        Abi.FunctionCall call = abi.encodeFunction("transferWithAuthorization",
+            from, to, value,
+            BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce,
+            BigInteger.valueOf(sig.v()), sig.r(), sig.s());
+
+        TransactionRequest txRequest = TxBuilder.eip1559()
+            .to(tokenAddress)
+            .data(new HexData(call.data()))
+            .build();
+
+        client.sendTransactionAndWait(txRequest, 30_000, 500);
+
+        assertTrue(getAuthorizationState(client, from, nonce));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // receiveWithAuthorization
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(3)
+    @DisplayName("receiveWithAuthorization: payee submits on-chain, verify balance changed")
+    void receiveWithAuthorization_works(Brane.Tester tester) {
+        Address from = signer.address();
+        Address to = recipientSigner.address();
+        BigInteger value = BigInteger.valueOf(500_000); // 0.5 USDC
+
+        BigInteger fromBefore = getBalance(tester, from);
+        BigInteger toBefore = getBalance(tester, to);
+
+        byte[] nonce = Eip3009.randomNonce();
+        var auth = Eip3009.receiveAuthorization(
+            from, to, value, BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce);
+        Signature sig = Eip3009.sign(auth, domain, signer);
+
+        Abi.FunctionCall call = abi.encodeFunction("receiveWithAuthorization",
+            from, to, value,
+            BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce,
+            BigInteger.valueOf(sig.v()), sig.r(), sig.s());
+
+        // Must be submitted by the payee (msg.sender == to)
+        try (ImpersonationSession session = tester.impersonate(to)) {
+            TransactionRequest txRequest = TxBuilder.eip1559()
+                .to(tokenAddress)
+                .data(new HexData(call.data()))
+                .build();
+
+            TransactionReceipt receipt = session.sendTransactionAndWait(txRequest);
+            assertTrue(receipt.status(), "receiveWithAuthorization failed");
+        }
+
+        BigInteger fromAfter = getBalance(tester, from);
+        BigInteger toAfter = getBalance(tester, to);
+        assertEquals(fromBefore.subtract(value), fromAfter);
+        assertEquals(toBefore.add(value), toAfter);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // cancelAuthorization
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    @Order(4)
+    @DisplayName("cancelAuthorization: cancel then verify transfer fails")
+    void cancelAuthorization_preventsTransfer(Brane.Signer client) {
+        Address from = signer.address();
+        Address to = recipientSigner.address();
+        BigInteger value = BigInteger.valueOf(100);
+
+        byte[] nonce = Eip3009.randomNonce();
+
+        // Sign a cancel for this nonce
+        var cancel = Eip3009.cancelAuthorization(from, nonce);
+        Signature cancelSig = Eip3009.sign(cancel, domain, signer);
+
+        Abi.FunctionCall cancelCall = abi.encodeFunction("cancelAuthorization",
+            from, nonce,
+            BigInteger.valueOf(cancelSig.v()), cancelSig.r(), cancelSig.s());
+
+        TransactionRequest cancelTx = TxBuilder.eip1559()
+            .to(tokenAddress)
+            .data(new HexData(cancelCall.data()))
+            .build();
+
+        TransactionReceipt cancelReceipt = client.sendTransactionAndWait(cancelTx, 30_000, 500);
+        assertTrue(cancelReceipt.status(), "cancelAuthorization failed");
+
+        // Verify nonce is consumed
+        assertTrue(getAuthorizationState(client, from, nonce));
+
+        // Now try to use the same nonce for a transfer — should revert
+        var auth = Eip3009.transferAuthorization(
+            from, to, value, BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce);
+        Signature transferSig = Eip3009.sign(auth, domain, signer);
+
+        Abi.FunctionCall transferCall = abi.encodeFunction("transferWithAuthorization",
+            from, to, value,
+            BigInteger.ZERO, BigInteger.valueOf(2_000_000_000L), nonce,
+            BigInteger.valueOf(transferSig.v()), transferSig.r(), transferSig.s());
+
+        TransactionRequest transferTx = TxBuilder.eip1559()
+            .to(tokenAddress)
+            .data(new HexData(transferCall.data()))
+            .build();
+
+        assertThrows(RevertException.class,
+            () -> client.sendTransactionAndWait(transferTx, 30_000, 500),
+            "Transfer should have reverted after cancel");
+    }
+}

--- a/foundry/anvil-tests/src/MockEip3009Token.sol
+++ b/foundry/anvil-tests/src/MockEip3009Token.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+/**
+ * Minimal mock EIP-3009 token for integration testing.
+ * Implements transferWithAuthorization, receiveWithAuthorization,
+ * cancelAuthorization, and authorizationState.
+ */
+contract MockEip3009Token {
+    string public name;
+    string public version;
+    uint8 public constant decimals = 6;
+
+    mapping(address => uint256) private _balances;
+    mapping(address => mapping(bytes32 => bool)) private _authorizationStates;
+
+    bytes32 public DOMAIN_SEPARATOR;
+
+    bytes32 private constant TRANSFER_WITH_AUTHORIZATION_TYPEHASH =
+        keccak256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)");
+
+    bytes32 private constant RECEIVE_WITH_AUTHORIZATION_TYPEHASH =
+        keccak256("ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)");
+
+    bytes32 private constant CANCEL_AUTHORIZATION_TYPEHASH =
+        keccak256("CancelAuthorization(address authorizer,bytes32 nonce)");
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
+    event AuthorizationCanceled(address indexed authorizer, bytes32 indexed nonce);
+
+    constructor(string memory _name, string memory _version, uint256 initialSupply) {
+        name = _name;
+        version = _version;
+        _balances[msg.sender] = initialSupply;
+        emit Transfer(address(0), msg.sender, initialSupply);
+
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes(_name)),
+            keccak256(bytes(_version)),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function authorizationState(address authorizer, bytes32 nonce) external view returns (bool) {
+        return _authorizationStates[authorizer][nonce];
+    }
+
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(block.timestamp > validAfter, "Authorization not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[from][nonce], "Authorization already used");
+
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+        address recovered = ecrecover(digest, v, r, s);
+        require(recovered != address(0) && recovered == from, "Invalid signature");
+
+        _authorizationStates[from][nonce] = true;
+        _balances[from] -= value;
+        _balances[to] += value;
+
+        emit Transfer(from, to, value);
+        emit AuthorizationUsed(from, nonce);
+    }
+
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(to == msg.sender, "Caller must be the payee");
+        require(block.timestamp > validAfter, "Authorization not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[from][nonce], "Authorization already used");
+
+        bytes32 structHash = keccak256(abi.encode(
+            RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+        address recovered = ecrecover(digest, v, r, s);
+        require(recovered != address(0) && recovered == from, "Invalid signature");
+
+        _authorizationStates[from][nonce] = true;
+        _balances[from] -= value;
+        _balances[to] += value;
+
+        emit Transfer(from, to, value);
+        emit AuthorizationUsed(from, nonce);
+    }
+
+    function cancelAuthorization(
+        address authorizer,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(!_authorizationStates[authorizer][nonce], "Authorization already used");
+
+        bytes32 structHash = keccak256(abi.encode(
+            CANCEL_AUTHORIZATION_TYPEHASH, authorizer, nonce
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+        address recovered = ecrecover(digest, v, r, s);
+        require(recovered != address(0) && recovered == authorizer, "Invalid signature");
+
+        _authorizationStates[authorizer][nonce] = true;
+        emit AuthorizationCanceled(authorizer, nonce);
+    }
+}

--- a/website/docs/pages/docs/signer/eip3009.mdx
+++ b/website/docs/pages/docs/signer/eip3009.mdx
@@ -55,10 +55,9 @@ Brane provides pre-configured domain builders for common EIP-3009 tokens:
 ### USDC
 
 ```java
-// USDC uses domain name "USD Coin" and version "2" across all chains
+// USDC uses domain name "USD Coin" and version "2" across all supported chains
+Eip712Domain domain = Eip3009.usdcDomain(8453L, usdcAddress);    // Base (primary x402 chain)
 Eip712Domain domain = Eip3009.usdcDomain(1L, usdcAddress);       // Ethereum
-Eip712Domain domain = Eip3009.usdcDomain(8453L, usdcAddress);    // Base
-Eip712Domain domain = Eip3009.usdcDomain(42161L, usdcAddress);   // Arbitrum
 ```
 
 ### EURC

--- a/website/docs/pages/docs/signer/eip3009.mdx
+++ b/website/docs/pages/docs/signer/eip3009.mdx
@@ -1,0 +1,190 @@
+# EIP-3009 Gasless Transfers
+
+## Overview
+
+EIP-3009 enables **gasless token transfers** via signed EIP-712 authorizations. Instead of the token holder submitting an on-chain transaction (and paying gas), they sign an authorization off-chain and a relayer submits it.
+
+This is the on-chain primitive powering [x402](https://www.x402.org/) — Coinbase's HTTP-native payment protocol for USDC.
+
+| Authorization Type | Purpose |
+|---|---|
+| **TransferWithAuthorization** | Transfer tokens from signer to any recipient |
+| **ReceiveWithAuthorization** | Transfer tokens where `msg.sender` must be the recipient (front-run protection) |
+| **CancelAuthorization** | Cancel an outstanding authorization before it is used |
+
+## Quick Start
+
+```java
+import sh.brane.core.crypto.PrivateKeySigner;
+import sh.brane.core.crypto.Signature;
+import sh.brane.core.crypto.eip3009.Eip3009;
+import sh.brane.core.crypto.eip3009.TransferAuthorization;
+import sh.brane.core.crypto.eip712.Eip712Domain;
+import sh.brane.core.types.Address;
+
+import java.math.BigInteger;
+
+// Create signer
+var signer = new PrivateKeySigner("0x...");
+
+// USDC domain on Base
+Address usdcAddress = new Address("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+Eip712Domain domain = Eip3009.usdcDomain(8453L, usdcAddress);
+
+// Create authorization (valid for 1 hour, auto nonce)
+TransferAuthorization auth = Eip3009.transferAuthorization(
+        signer.address(),
+        new Address("0x70997970c51812dc3a010c7d01b50e0d17dc79c8"),
+        BigInteger.valueOf(1_000_000),  // 1 USDC (6 decimals)
+        3600                            // valid for 1 hour
+);
+
+// Sign
+Signature sig = Eip3009.sign(auth, domain, signer);
+
+// Extract v, r, s for on-chain submission
+int v = sig.v();
+byte[] r = sig.r();
+byte[] s = sig.s();
+```
+
+## Domain Helpers
+
+Brane provides pre-configured domain builders for common EIP-3009 tokens:
+
+### USDC
+
+```java
+// USDC uses domain name "USD Coin" and version "2" across all chains
+Eip712Domain domain = Eip3009.usdcDomain(1L, usdcAddress);       // Ethereum
+Eip712Domain domain = Eip3009.usdcDomain(8453L, usdcAddress);    // Base
+Eip712Domain domain = Eip3009.usdcDomain(42161L, usdcAddress);   // Arbitrum
+```
+
+### EURC
+
+```java
+// EURC uses domain name "EURC" and version "2"
+Eip712Domain domain = Eip3009.eurcDomain(1L, eurcAddress);
+```
+
+### Custom Token
+
+```java
+// Any EIP-3009 token with custom domain parameters
+Eip712Domain domain = Eip3009.tokenDomain(
+        "My Token",       // EIP-712 domain name
+        "1",              // EIP-712 domain version
+        1L,               // chain ID
+        tokenAddress      // contract address
+);
+```
+
+:::warning
+The domain name and version must exactly match what the token contract uses in its `DOMAIN_SEPARATOR`. Check the token's documentation or read the contract to confirm these values.
+:::
+
+## Authorization Types
+
+### TransferWithAuthorization
+
+The standard authorization for transferring tokens. Any address can submit this on-chain.
+
+```java
+// Convenience factory (auto nonce + time window)
+TransferAuthorization auth = Eip3009.transferAuthorization(
+        from,                           // payer address
+        to,                             // payee address
+        BigInteger.valueOf(1_000_000),  // amount in smallest units
+        3600                            // valid for 1 hour
+);
+
+// Explicit factory (for deterministic testing)
+TransferAuthorization auth = Eip3009.transferAuthorization(
+        from, to, value,
+        BigInteger.ZERO,                    // validAfter (unix seconds)
+        BigInteger.valueOf(2_000_000_000L), // validBefore (unix seconds)
+        nonce                               // 32-byte random nonce
+);
+```
+
+### ReceiveWithAuthorization
+
+Like `TransferWithAuthorization` but requires `msg.sender == to`. This prevents front-running by ensuring only the intended recipient can submit the authorization on-chain.
+
+```java
+ReceiveAuthorization auth = Eip3009.receiveAuthorization(
+        from, to, value, 3600  // valid for 1 hour
+);
+
+Signature sig = Eip3009.sign(auth, domain, signer);
+```
+
+### CancelAuthorization
+
+Cancel an outstanding authorization before it is used. Once canceled, the nonce is permanently consumed and cannot be reused.
+
+```java
+import sh.brane.core.crypto.eip3009.CancelAuthorization;
+
+// Cancel a specific authorization by its nonce
+CancelAuthorization cancel = Eip3009.cancelAuthorization(
+        signerAddress,  // the address that signed the original authorization
+        originalNonce   // the 32-byte nonce to cancel
+);
+
+Signature sig = Eip3009.sign(cancel, domain, signer);
+```
+
+## Signing and Hashing
+
+### Signing
+
+All authorization types use the same `Eip3009.sign()` method:
+
+```java
+Signature sig = Eip3009.sign(auth, domain, signer);
+```
+
+### Hashing Without Signing
+
+Compute the EIP-712 hash without signing (useful for verification or logging):
+
+```java
+import sh.brane.core.types.Hash;
+
+Hash hash = Eip3009.hash(auth, domain);
+```
+
+## Nonce Generation
+
+EIP-3009 uses **random** `bytes32` nonces (not sequential), allowing multiple concurrent authorizations without ordering constraints:
+
+```java
+byte[] nonce = Eip3009.randomNonce();  // 32 cryptographically random bytes
+```
+
+The convenience factory methods (`transferAuthorization(from, to, value, validForSeconds)`) generate a random nonce automatically.
+
+## On-Chain Submission
+
+After signing, pass the authorization parameters and signature to the token contract:
+
+```java
+// Parameters for transferWithAuthorization(from, to, value, validAfter, validBefore, nonce, v, r, s)
+Address from = auth.from();
+Address to = auth.to();
+BigInteger value = auth.value();
+BigInteger validAfter = auth.validAfter();
+BigInteger validBefore = auth.validBefore();
+byte[] nonce = auth.nonce();
+int v = sig.v();
+byte[] r = sig.r();
+byte[] s = sig.s();
+```
+
+## See Also
+
+- [EIP-712 Typed Data](/docs/signer/eip712) — The underlying signing mechanism
+- [Signers](/docs/signer/signers) — Signer interface and PrivateKeySigner
+- [EIP-3009 Specification](https://eips.ethereum.org/EIPS/eip-3009) — Full EIP specification

--- a/website/docs/pages/docs/signer/eip712.mdx
+++ b/website/docs/pages/docs/signer/eip712.mdx
@@ -355,5 +355,6 @@ try {
 
 ## See Also
 
+- [EIP-3009 Gasless Transfers](/docs/signer/eip3009) - Gasless token transfers (USDC, EURC) built on EIP-712
 - [Signers](/docs/signer/signers) - Signer interface and PrivateKeySigner
 - [Sending Transactions](/docs/signer/api) - Transaction signing with Brane.Signer

--- a/website/vocs.config.tsx
+++ b/website/vocs.config.tsx
@@ -84,6 +84,7 @@ export default defineConfig({
           { text: 'Signers', link: '/docs/signer/signers' },
           { text: 'HD Wallets', link: '/docs/signer/hd-wallets' },
           { text: 'EIP-712 Typed Data', link: '/docs/signer/eip712' },
+          { text: 'EIP-3009 Gasless Transfers', link: '/docs/signer/eip3009' },
           { text: 'Blob Transactions', link: '/docs/signer/blobs' },
           { text: 'Custom Signers', link: '/docs/signer/custom-signers' },
         ],


### PR DESCRIPTION
## Summary

- Add EIP-3009 off-chain signing primitives for gasless token transfers (USDC/EURC via x402)
- `TransferWithAuthorization`, `ReceiveWithAuthorization`, `CancelAuthorization` message types with EIP-712 signing
- Domain helpers (`usdcDomain`, `eurcDomain`, `tokenDomain`), convenience factories with auto nonces/validity windows
- Full test suite: typehash verification, sign/recover round-trips, record validation, on-chain integration tests with mock Solidity contract

## Test plan

- [x] Unit tests pass (`Eip3009Test`, `TransferAuthorizationTest`)
- [x] Integration tests pass with Anvil (`Eip3009IntegrationTest` — transfer, receive, cancel flows)
- [x] Example runs successfully (`Eip3009Example`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/noise-xyz/brane/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
